### PR TITLE
Updated modules, deleted depreciated functions. Compiles again.

### DIFF
--- a/modules/FindGLFW.cmake
+++ b/modules/FindGLFW.cmake
@@ -1,0 +1,137 @@
+#.rst:
+# Find GLFW
+# ---------
+#
+# Finds the GLFW library using its cmake config if that exists, otherwise
+# falls back to finding it manually. This module defines:
+#
+#  GLFW_FOUND               - True if GLFW library is found
+#  GLFW::GLFW               - GLFW imported target
+#
+# Additionally, in case the config was not found, these variables are defined
+# for internal usage:
+#
+#  GLFW_LIBRARY             - GLFW library
+#  GLFW_DLL_DEBUG           - GLFW debug DLL on Windows, if found
+#  GLFW_DLL_RELEASE         - GLFW release DLL on Windows, if found
+#  GLFW_INCLUDE_DIR         - Root include dir
+#
+
+#
+#   This file is part of Magnum.
+#
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020 Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2016 Jonathan Hale <squareys@googlemail.com>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+# GLFW installs cmake package config files which handles dependencies in case
+# GLFW is built statically. Try to find first, quietly, so it doesn't print
+# loud messages when it's not found, since that's okay. If the glfw target
+# already exists, it means we're using it through a CMake subproject -- don't
+# attempt to find the package in that case.
+if(NOT TARGET glfw)
+    find_package(glfw3 CONFIG QUIET)
+endif()
+
+# If either a glfw config file was found or we have a subproject, point
+# GLFW::GLFW to that and exit -- nothing else to do here.
+if(TARGET glfw)
+    if(NOT TARGET GLFW::GLFW)
+        # Aliases of (global) targets are only supported in CMake 3.11, so we
+        # work around it by this. This is easier than fetching all possible
+        # properties (which are impossible to track of) and then attempting to
+        # rebuild them into a new target.
+        add_library(GLFW::GLFW INTERFACE IMPORTED)
+        set_target_properties(GLFW::GLFW PROPERTIES INTERFACE_LINK_LIBRARIES glfw)
+    endif()
+
+    # Just to make FPHSA print some meaningful location, nothing else
+    get_target_property(_GLFW_INTERFACE_INCLUDE_DIRECTORIES glfw INTERFACE_INCLUDE_DIRECTORIES)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args("GLFW" DEFAULT_MSG
+        _GLFW_INTERFACE_INCLUDE_DIRECTORIES)
+
+    if(CORRADE_TARGET_WINDOWS)
+        # .dll is in LOCATION, .lib is in IMPLIB. Yay, useful!
+        get_target_property(GLFW_DLL_DEBUG glfw IMPORTED_LOCATION_DEBUG)
+        get_target_property(GLFW_DLL_RELEASE glfw IMPORTED_LOCATION_RELEASE)
+    endif()
+
+    return()
+endif()
+
+if(CORRADE_TARGET_WINDOWS)
+    if(MSVC)
+        if(MSVC_VERSION VERSION_LESS 1910)
+            set(_GLFW_LIBRARY_PATH_SUFFIX lib-vc2015)
+        elseif(MSVC_VERSION VERSION_LESS 1920)
+            set(_GLFW_LIBRARY_PATH_SUFFIX lib-vc2017)
+        elseif(MSVC_VERSION VERSION_LESS 1930)
+            set(_GLFW_LIBRARY_PATH_SUFFIX lib-vc2019)
+        else()
+            message(FATAL_ERROR "Unsupported MSVC version")
+        endif()
+    elseif(MINGW)
+        set(_GLFW_LIBRARY_PATH_SUFFIX lib-mingw-w64)
+    else()
+        message(FATAL_ERROR "Unsupported compiler")
+    endif()
+endif()
+
+# In case no config file was found, try manually finding the library. Prefer
+# the glfw3dll as it's a dynamic library.
+find_library(GLFW_LIBRARY
+    NAMES glfw glfw3dll glfw3
+    PATH_SUFFIXES ${_GLFW_LIBRARY_PATH_SUFFIX})
+
+if(CORRADE_TARGET_WINDOWS AND GLFW_LIBRARY MATCHES "glfw3dll.(lib|a)$")
+    # TODO: debug?
+    find_file(GLFW_DLL_RELEASE
+        NAMES glfw3.dll
+        PATH_SUFFIXES ${_GLFW_LIBRARY_PATH_SUFFIX})
+endif()
+
+# Include dir
+find_path(GLFW_INCLUDE_DIR
+    NAMES GLFW/glfw3.h)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args("GLFW" DEFAULT_MSG
+    GLFW_LIBRARY
+    GLFW_INCLUDE_DIR)
+
+if(NOT TARGET GLFW::GLFW)
+    add_library(GLFW::GLFW UNKNOWN IMPORTED)
+
+    # Work around BUGGY framework support on macOS
+    # https://cmake.org/Bug/view.php?id=14105
+    if(CORRADE_TARGET_APPLE AND GLFW_LIBRARY MATCHES "\\.framework$")
+        set_property(TARGET GLFW::GLFW PROPERTY IMPORTED_LOCATION ${GLFW_LIBRARY}/GLFW)
+    else()
+        set_property(TARGET GLFW::GLFW PROPERTY IMPORTED_LOCATION ${GLFW_LIBRARY})
+    endif()
+
+    set_property(TARGET GLFW::GLFW PROPERTY
+        INTERFACE_INCLUDE_DIRECTORIES ${GLFW_INCLUDE_DIR})
+endif()
+
+mark_as_advanced(GLFW_LIBRARY GLFW_INCLUDE_DIR)

--- a/modules/FindMagnum.cmake
+++ b/modules/FindMagnum.cmake
@@ -25,19 +25,27 @@
 #  MAGNUM_PLUGINS_DIR           - Base directory with dynamic plugins, defaults
 #   to :variable:`MAGNUM_PLUGINS_RELEASE_DIR` in release builds and
 #   multi-configuration builds or to :variable:`MAGNUM_PLUGINS_DEBUG_DIR` in
-#   debug builds. You can modify all three variables (e.g. set them to ``.``
-#   when deploying on Windows with plugins stored relatively to the
-#   executable), the following ``MAGNUM_PLUGINS_*_DIR`` variables depend on it.
+#   debug builds
 #  MAGNUM_PLUGINS_FONT[|_DEBUG|_RELEASE]_DIR - Directory with dynamic font
 #   plugins
 #  MAGNUM_PLUGINS_FONTCONVERTER[|_DEBUG|_RELEASE]_DIR - Directory with dynamic
 #   font converter plugins
 #  MAGNUM_PLUGINS_IMAGECONVERTER[|_DEBUG|_RELEASE]_DIR - Directory with dynamic
 #   image converter plugins
+#  MAGNUM_PLUGINS_SCENECONVERTER[|_DEBUG|_RELEASE]_DIR - Directory with dynamic
+#   scene converter plugins
 #  MAGNUM_PLUGINS_IMPORTER[|_DEBUG|_RELEASE]_DIR  - Directory with dynamic
 #   importer plugins
 #  MAGNUM_PLUGINS_AUDIOIMPORTER[|_DEBUG|_RELEASE]_DIR - Directory with dynamic
 #   audio importer plugins
+#
+# If Magnum is built for Emscripten, the following variables contain paths to
+# various support files:
+#
+#  MAGNUM_EMSCRIPTENAPPLICATION_JS - Path to the EmscriptenApplication.js file
+#  MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS - Path to the
+#   WindowlessEmscriptenApplication.js file
+#  MAGNUM_WEBAPPLICATION_CSS    - Path to the WebApplication.css file
 #
 # This command will try to find only the base library, not the optional
 # components. The base library depends on Corrade and OpenGL libraries (or
@@ -47,6 +55,7 @@
 #  AnyAudioImporter             - Any audio importer
 #  AnyImageConverter            - Any image converter
 #  AnyImageImporter             - Any image importer
+#  AnySceneConverter            - Any scene converter
 #  AnySceneImporter             - Any scene importer
 #  Audio                        - Audio library
 #  DebugTools                   - DebugTools library
@@ -55,12 +64,13 @@
 #  Primitives                   - Primitives library
 #  SceneGraph                   - SceneGraph library
 #  Shaders                      - Shaders library
-#  Shapes                       - Shapes library
 #  Text                         - Text library
 #  TextureTools                 - TextureTools library
 #  Trade                        - Trade library
+#  Vk                           - Vk library
+#  AndroidApplication           - Android application
+#  EmscriptenApplication        - Emscripten application
 #  GlfwApplication              - GLFW application
-#  GlutApplication              - GLUT application
 #  GlxApplication               - GLX application
 #  Sdl2Application              - SDL2 application
 #  XEglApplication              - X/EGL application
@@ -84,12 +94,13 @@
 #  distancefieldconverter       - magnum-distancefieldconverter executable
 #  fontconverter                - magnum-fontconverter executable
 #  imageconverter               - magnum-imageconverter executable
+#  sceneconverterter            - magnum-sceneconverter executable
 #  gl-info                      - magnum-gl-info executable
 #  al-info                      - magnum-al-info executable
 #
 # Example usage with specifying additional components is::
 #
-#  find_package(Magnum REQUIRED Trade MeshTools Primitives GlutApplication)
+#  find_package(Magnum REQUIRED Trade MeshTools Primitives GlfwApplication)
 #
 # For each component is then defined:
 #
@@ -118,8 +129,8 @@
 #  MAGNUM_BUILD_DEPRECATED      - Defined if compiled with deprecated APIs
 #   included
 #  MAGNUM_BUILD_STATIC          - Defined if compiled as static libraries
-#  MAGNUM_BUILD_MULTITHREADED   - Defined if compiled in a way that allows
-#   having multiple thread-local Magnum contexts
+#  MAGNUM_BUILD_STATIC_UNIQUE_GLOBALS - Defined if static libraries keep the
+#   globals unique even across different shared libraries
 #  MAGNUM_TARGET_GL             - Defined if compiled with OpenGL interop
 #  MAGNUM_TARGET_GLES           - Defined if compiled for OpenGL ES
 #  MAGNUM_TARGET_GLES2          - Defined if compiled for OpenGL ES 2.0
@@ -128,6 +139,14 @@
 #   emulation on desktop OpenGL
 #  MAGNUM_TARGET_WEBGL          - Defined if compiled for WebGL
 #  MAGNUM_TARGET_HEADLESS       - Defined if compiled for headless machines
+#  MAGNUM_TARGET_VK             - Defined if compiled with Vulkan interop
+#
+# The following variables are provided for backwards compatibility purposes
+# only when MAGNUM_BUILD_DEPRECATED is enabled and will be removed in a future
+# release:
+#
+#  MAGNUM_BUILD_MULTITHREADED   - Alias to CORRADE_BUILD_MULTITHREADED. Use
+#   CORRADE_BUILD_MULTITHREADED instead.
 #
 # Additionally these variables are defined for internal usage:
 #
@@ -161,6 +180,10 @@
 #   plugin binary installation directory
 #  MAGNUM_PLUGINS_IMPORTER_[DEBUG|RELEASE]_LIBRARY_INSTALL_DIR  - Importer
 #   plugin library installation directory
+#  MAGNUM_PLUGINS_SCENECONVERTER_[DEBUG|RELEASE]_BINARY_INSTALL_DIR - Scene
+#   converter plugin binary installation directory
+#  MAGNUM_PLUGINS_SCENECONVERTER_[DEBUG|RELEASE]_LIBRARY_INSTALL_DIR - Scene
+#   converter plugin library installation directory
 #  MAGNUM_PLUGINS_AUDIOIMPORTER_[DEBUG|RELEASE]_BINARY_INSTALL_DIR - Audio
 #   importer plugin binary installation directory
 #  MAGNUM_PLUGINS_AUDIOIMPORTER_[DEBUG|RELEASE]_LIBRARY_INSTALL_DIR - Audio
@@ -168,27 +191,12 @@
 #  MAGNUM_INCLUDE_INSTALL_DIR   - Header installation directory
 #  MAGNUM_PLUGINS_INCLUDE_INSTALL_DIR - Plugin header installation directory
 #
-# Workflows without imported targets are deprecated and the following variables
-# are included just for backwards compatibility and only if
-# :variable:`MAGNUM_BUILD_DEPRECATED` is enabled:
-#
-#  MAGNUM_LIBRARIES             - Expands to ``Magnum::Magnum`` target. Use
-#   ``Magnum::Magnum`` target directly instead.
-#  MAGNUM_*_LIBRARIES           - Expands to ``Magnum::*`` target. Use
-#   ``Magnum::*`` target directly instead.
-#  MAGNUM_APPLICATION_LIBRARIES / MAGNUM_WINDOWLESSAPPLICATION_LIBRARIES
-#                               - Expands to ``Magnum::Application`` /
-#   ``Magnum::WindowlessApplication`` target. Use ``Magnum::Application`` /
-#   ``Magnum::WindowlessApplication`` target directly instead.
-#  MAGNUM_CONTEXT_LIBRARIES     - Expands to ``Magnum::Context`` target. Use
-#   ``Magnum::Context`` target directly instead.
-#
 
 #
 #   This file is part of Magnum.
 #
-#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018
-#             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020 Vladimír Vondruš <mosra@centrum.cz>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -226,12 +234,12 @@ find_package(Corrade REQUIRED Utility ${_MAGNUM_CORRADE_DEPENDENCIES})
 
 # Root include dir
 find_path(MAGNUM_INCLUDE_DIR
-        NAMES Magnum/Magnum.h)
+    NAMES Magnum/Magnum.h)
 mark_as_advanced(MAGNUM_INCLUDE_DIR)
 
 # Configuration file
 find_file(_MAGNUM_CONFIGURE_FILE configure.h
-        HINTS ${MAGNUM_INCLUDE_DIR}/Magnum/)
+    HINTS ${MAGNUM_INCLUDE_DIR}/Magnum/)
 mark_as_advanced(_MAGNUM_CONFIGURE_FILE)
 
 # We need to open configure.h file from MAGNUM_INCLUDE_DIR before we check for
@@ -240,28 +248,44 @@ mark_as_advanced(_MAGNUM_CONFIGURE_FILE)
 if(NOT MAGNUM_INCLUDE_DIR)
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(Magnum
-            REQUIRED_VARS MAGNUM_INCLUDE_DIR _MAGNUM_CONFIGURE_FILE)
+        REQUIRED_VARS MAGNUM_INCLUDE_DIR _MAGNUM_CONFIGURE_FILE)
 endif()
 
 # Read flags from configuration
 file(READ ${_MAGNUM_CONFIGURE_FILE} _magnumConfigure)
+string(REGEX REPLACE ";" "\\\\;" _magnumConfigure "${_magnumConfigure}")
+string(REGEX REPLACE "\n" ";" _magnumConfigure "${_magnumConfigure}")
 set(_magnumFlags
-        BUILD_DEPRECATED
-        BUILD_STATIC
-        BUILD_MULTITHREADED
-        TARGET_GL
-        TARGET_GLES
-        TARGET_GLES2
-        TARGET_GLES3
-        TARGET_DESKTOP_GLES
-        TARGET_WEBGL
-        TARGET_HEADLESS)
+    BUILD_DEPRECATED
+    BUILD_STATIC
+    BUILD_STATIC_UNIQUE_GLOBALS
+    TARGET_GL
+    TARGET_GLES
+    TARGET_GLES2
+    TARGET_GLES3
+    TARGET_DESKTOP_GLES
+    TARGET_WEBGL
+    TARGET_HEADLESS
+    TARGET_VK)
 foreach(_magnumFlag ${_magnumFlags})
-    string(FIND "${_magnumConfigure}" "#define MAGNUM_${_magnumFlag}" _magnum_${_magnumFlag})
+    list(FIND _magnumConfigure "#define MAGNUM_${_magnumFlag}" _magnum_${_magnumFlag})
     if(NOT _magnum_${_magnumFlag} EQUAL -1)
         set(MAGNUM_${_magnumFlag} 1)
     endif()
 endforeach()
+
+# For compatibility only, to be removed at some point
+if(MAGNUM_BUILD_DEPRECATED AND CORRADE_BUILD_MULTITHREADED)
+    set(MAGNUM_BUILD_MULTITHREADED 1)
+endif()
+
+# OpenGL library preference. Prefer to use GLVND, since that's the better
+# approach nowadays, but allow the users to override it from outside in case
+# it is broken for some reason (Nvidia drivers in Debian's testing (Buster) --
+# reported on 2019-04-09).
+if(NOT CMAKE_VERSION VERSION_LESS 3.10 AND NOT OpenGL_GL_PREFERENCE)
+    set(OpenGL_GL_PREFERENCE GLVND)
+endif()
 
 # Base Magnum library
 if(NOT TARGET Magnum::Magnum)
@@ -271,7 +295,7 @@ if(NOT TARGET Magnum::Magnum)
     find_library(MAGNUM_LIBRARY_DEBUG Magnum-d)
     find_library(MAGNUM_LIBRARY_RELEASE Magnum)
     mark_as_advanced(MAGNUM_LIBRARY_DEBUG
-            MAGNUM_LIBRARY_RELEASE)
+        MAGNUM_LIBRARY_RELEASE)
 
     # Set the MAGNUM_LIBRARY variable based on what was found, use that
     # information to guess also build type of dynamic plugins
@@ -299,31 +323,31 @@ if(NOT TARGET Magnum::Magnum)
 
     if(MAGNUM_LIBRARY_RELEASE)
         set_property(TARGET Magnum::Magnum APPEND PROPERTY
-                IMPORTED_CONFIGURATIONS RELEASE)
+            IMPORTED_CONFIGURATIONS RELEASE)
         set_property(TARGET Magnum::Magnum PROPERTY
-                IMPORTED_LOCATION_RELEASE ${MAGNUM_LIBRARY_RELEASE})
+            IMPORTED_LOCATION_RELEASE ${MAGNUM_LIBRARY_RELEASE})
     endif()
 
     if(MAGNUM_LIBRARY_DEBUG)
         set_property(TARGET Magnum::Magnum APPEND PROPERTY
-                IMPORTED_CONFIGURATIONS DEBUG)
+            IMPORTED_CONFIGURATIONS DEBUG)
         set_property(TARGET Magnum::Magnum PROPERTY
-                IMPORTED_LOCATION_DEBUG ${MAGNUM_LIBRARY_DEBUG})
+            IMPORTED_LOCATION_DEBUG ${MAGNUM_LIBRARY_DEBUG})
     endif()
 
     # Include directories
     set_property(TARGET Magnum::Magnum APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-            ${MAGNUM_INCLUDE_DIR})
+        ${MAGNUM_INCLUDE_DIR})
     # Some deprecated APIs use headers (but not externally defined symbols)
     # from the GL library, link those includes as well
-    if(MAGNUM_BUILD_DEPRECATED)
+    if(MAGNUM_BUILD_DEPRECATED AND MAGNUM_TARGET_GL)
         set_property(TARGET Magnum::Magnum APPEND PROPERTY
-                INTERFACE_INCLUDE_DIRECTORIES ${MAGNUM_INCLUDE_DIR}/MagnumExternal/OpenGL)
+            INTERFACE_INCLUDE_DIRECTORIES ${MAGNUM_INCLUDE_DIR}/MagnumExternal/OpenGL)
     endif()
 
     # Dependent libraries
     set_property(TARGET Magnum::Magnum APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-            Corrade::Utility)
+         Corrade::Utility)
 else()
     set(MAGNUM_LIBRARY Magnum::Magnum)
 endif()
@@ -331,34 +355,44 @@ endif()
 # Component distinction (listing them explicitly to avoid mistakes with finding
 # components from other repositories)
 set(_MAGNUM_LIBRARY_COMPONENT_LIST
-        Audio DebugTools GL MeshTools Primitives SceneGraph Shaders Shapes Text
-        TextureTools Trade
-        AndroidApplication GlfwApplication GlutApplication GlxApplication
-        Sdl2Application XEglApplication WindowlessCglApplication
-        WindowlessEglApplication WindowlessGlxApplication WindowlessIosApplication WindowlessWglApplication WindowlessWindowsEglApplication
-        CglContext EglContext GlxContext WglContext
-        OpenGLTester)
+    Audio DebugTools GL MeshTools Primitives SceneGraph Shaders Text
+    TextureTools Trade Vk
+    AndroidApplication EmscriptenApplication GlfwApplication GlxApplication
+    Sdl2Application XEglApplication WindowlessCglApplication
+    WindowlessEglApplication WindowlessGlxApplication WindowlessIosApplication
+    WindowlessWglApplication WindowlessWindowsEglApplication
+    CglContext EglContext GlxContext WglContext
+    OpenGLTester)
 set(_MAGNUM_PLUGIN_COMPONENT_LIST
-        AnyAudioImporter AnyImageConverter AnyImageImporter AnySceneImporter
-        MagnumFont MagnumFontConverter ObjImporter TgaImageConverter TgaImporter
-        WavAudioImporter)
+    AnyAudioImporter AnyImageConverter AnyImageImporter AnySceneConverter
+    AnySceneImporter MagnumFont MagnumFontConverter ObjImporter
+    TgaImageConverter TgaImporter WavAudioImporter)
 set(_MAGNUM_EXECUTABLE_COMPONENT_LIST
-        distancefieldconverter fontconverter imageconverter gl-info al-info)
+    distancefieldconverter fontconverter imageconverter sceneconverter gl-info
+    al-info)
 
 # Inter-component dependencies
 set(_MAGNUM_Audio_DEPENDENCIES )
 
-set(_MAGNUM_DebugTools_DEPENDENCIES )
+# Trade is used by CompareImage. If Trade is not enabled, CompareImage is not
+# compiled at all.
+set(_MAGNUM_DebugTools_DEPENDENCIES Trade)
+set(_MAGNUM_DebugTools_Trade_DEPENDENCY_IS_OPTIONAL ON)
+# MeshTools, Primitives, SceneGraph and Shaders are used only for GL renderers
+# in DebugTools. All of this is optional, compiled in only if the base library
+# was selected.
 if(MAGNUM_TARGET_GL)
-    # MeshTools, Primitives, SceneGraph, Shaders and Shapes are used only for
-    # GL renderers
-    list(APPEND _MAGNUM_DebugTools_DEPENDENCIES MeshTools Primitives SceneGraph Shaders Shapes Trade GL)
+    list(APPEND _MAGNUM_DebugTools_DEPENDENCIES MeshTools Primitives SceneGraph Shaders GL)
+    set(_MAGNUM_DebugTools_MeshTools_DEPENDENCY_IS_OPTIONAL ON)
+    set(_MAGNUM_DebugTools_Primitives_DEPENDENCY_IS_OPTIONAL ON)
+    set(_MAGNUM_DebugTools_SceneGraph_DEPENDENCY_IS_OPTIONAL ON)
+    set(_MAGNUM_DebugTools_Shaders_DEPENDENCY_IS_OPTIONAL ON)
+    set(_MAGNUM_DebugTools_GL_DEPENDENCY_IS_OPTIONAL ON)
 endif()
 
-set(_MAGNUM_MeshTools_DEPENDENCIES )
+set(_MAGNUM_MeshTools_DEPENDENCIES Trade)
 if(MAGNUM_TARGET_GL)
-    # Trade is used only in compile(), which needs GL as well
-    list(APPEND _MAGNUM_${_COMPONENT}_DEPENDENCIES Trade GL)
+    list(APPEND _MAGNUM_MeshTools_DEPENDENCIES GL)
 endif()
 
 set(_MAGNUM_OpenGLTester_DEPENDENCIES GL)
@@ -382,11 +416,17 @@ elseif(CORRADE_TARGET_WINDOWS)
     endif()
 endif()
 
-set(_MAGNUM_Primitives_DEPENDENCIES Trade)
+set(_MAGNUM_Primitives_DEPENDENCIES MeshTools Trade)
+if(MAGNUM_TARGET_GL)
+    # GL not required by Primitives themselves, but transitively by MeshTools
+    list(APPEND _MAGNUM_Primitives_DEPENDENCIES GL)
+endif()
 set(_MAGNUM_SceneGraph_DEPENDENCIES )
 set(_MAGNUM_Shaders_DEPENDENCIES GL)
-set(_MAGNUM_Shapes_DEPENDENCIES SceneGraph)
-set(_MAGNUM_Text_DEPENDENCIES TextureTools GL)
+set(_MAGNUM_Text_DEPENDENCIES TextureTools)
+if(MAGNUM_TARGET_GL)
+    list(APPEND _MAGNUM_Text_DEPENDENCIES GL)
+endif()
 
 set(_MAGNUM_TextureTools_DEPENDENCIES )
 if(MAGNUM_TARGET_GL)
@@ -395,13 +435,16 @@ endif()
 
 set(_MAGNUM_Trade_DEPENDENCIES )
 set(_MAGNUM_AndroidApplication_DEPENDENCIES GL)
+set(_MAGNUM_EmscriptenApplication_DEPENDENCIES)
+if(MAGNUM_TARGET_GL)
+    list(APPEND _MAGNUM_EmscriptenApplication_DEPENDENCIES GL)
+endif()
 
 set(_MAGNUM_GlfwApplication_DEPENDENCIES )
 if(MAGNUM_TARGET_GL)
     list(APPEND _MAGNUM_GlfwApplication_DEPENDENCIES GL)
 endif()
 
-set(_MAGNUM_GlutApplication_DEPENDENCIES GL)
 set(_MAGNUM_GlxApplication_DEPENDENCIES GL)
 
 set(_MAGNUM_Sdl2Application_DEPENDENCIES )
@@ -421,26 +464,30 @@ set(_MAGNUM_EglContext_DEPENDENCIES GL)
 set(_MAGNUM_GlxContext_DEPENDENCIES GL)
 set(_MAGNUM_WglContext_DEPENDENCIES GL)
 
-set(_MAGNUM_MagnumFont_DEPENDENCIES Trade TgaImporter) # and below
+set(_MAGNUM_MagnumFont_DEPENDENCIES Trade TgaImporter GL) # and below
 set(_MAGNUM_MagnumFontConverter_DEPENDENCIES Trade TgaImageConverter) # and below
 set(_MAGNUM_ObjImporter_DEPENDENCIES MeshTools) # and below
 foreach(_component ${_MAGNUM_PLUGIN_COMPONENT_LIST})
     if(_component MATCHES ".+AudioImporter")
         list(APPEND _MAGNUM_${_component}_DEPENDENCIES Audio)
-    elseif(_component MATCHES ".+(Importer|ImageConverter)")
+    elseif(_component MATCHES ".+(Importer|ImageConverter|SceneConverter)")
         list(APPEND _MAGNUM_${_component}_DEPENDENCIES Trade)
     elseif(_component MATCHES ".+(Font|FontConverter)")
-        list(APPEND _MAGNUM_${_component}_DEPENDENCIES Text TextureTools GL)
+        list(APPEND _MAGNUM_${_component}_DEPENDENCIES Text TextureTools)
     endif()
 endforeach()
 
 # Ensure that all inter-component dependencies are specified as well
 set(_MAGNUM_ADDITIONAL_COMPONENTS )
 foreach(_component ${Magnum_FIND_COMPONENTS})
-    # Mark the dependencies as required if the component is also required
+    # Mark the dependencies as required if the component is also required, but
+    # only if they themselves are not optional (for example parts of DebugTools
+    # are present only if their respective base library is compiled)
     if(Magnum_FIND_REQUIRED_${_component})
         foreach(_dependency ${_MAGNUM_${_component}_DEPENDENCIES})
-            set(Magnum_FIND_REQUIRED_${_dependency} TRUE)
+            if(NOT _MAGNUM_${_component}_${_dependency}_DEPENDENCY_IS_OPTIONAL)
+                set(Magnum_FIND_REQUIRED_${_dependency} TRUE)
+            endif()
         endforeach()
     endif()
 
@@ -462,7 +509,9 @@ foreach(_WHAT LIBRARY PLUGIN EXECUTABLE)
     set(_MAGNUM_${_WHAT}_COMPONENTS "^(${_MAGNUM_${_WHAT}_COMPONENTS})$")
 endforeach()
 
-# Find all components
+# Find all components. Maintain a list of components that'll need to have
+# their optional dependencies checked.
+set(_MAGNUM_OPTIONAL_DEPENDENCIES_TO_ADD )
 foreach(_component ${Magnum_FIND_COMPONENTS})
     string(TOUPPER ${_component} _COMPONENT)
 
@@ -484,7 +533,7 @@ foreach(_component ${Magnum_FIND_COMPONENTS})
             find_library(MAGNUM_${_COMPONENT}_LIBRARY_DEBUG Magnum${_component}-d)
             find_library(MAGNUM_${_COMPONENT}_LIBRARY_RELEASE Magnum${_component})
             mark_as_advanced(MAGNUM_${_COMPONENT}_LIBRARY_DEBUG
-                    MAGNUM_${_COMPONENT}_LIBRARY_RELEASE)
+                MAGNUM_${_COMPONENT}_LIBRARY_RELEASE)
         endif()
 
         # Plugin components
@@ -500,19 +549,23 @@ foreach(_component ${Magnum_FIND_COMPONENTS})
                 string(REPLACE "AudioImporter" "Importer" _MAGNUM_${_COMPONENT}_HEADER_NAME "${_component}")
                 set(_MAGNUM_${_COMPONENT}_INCLUDE_PATH_NAMES ${_MAGNUM_${_COMPONENT}_HEADER_NAME}.h)
 
-                # Importer plugin specific name suffixes
+            # Importer plugin specific name suffixes
             elseif(_component MATCHES ".+Importer$")
                 set(_MAGNUM_${_COMPONENT}_PATH_SUFFIX importers)
 
-                # Font plugin specific name suffixes
+            # Font plugin specific name suffixes
             elseif(_component MATCHES ".+Font$")
                 set(_MAGNUM_${_COMPONENT}_PATH_SUFFIX fonts)
 
-                # ImageConverter plugin specific name suffixes
+            # ImageConverter plugin specific name suffixes
             elseif(_component MATCHES ".+ImageConverter$")
                 set(_MAGNUM_${_COMPONENT}_PATH_SUFFIX imageconverters)
 
-                # FontConverter plugin specific name suffixes
+            # SceneConverter plugin specific name suffixes
+            elseif(_component MATCHES ".+SceneConverter$")
+                set(_MAGNUM_${_COMPONENT}_PATH_SUFFIX sceneconverters)
+
+            # FontConverter plugin specific name suffixes
             elseif(_component MATCHES ".+FontConverter$")
                 set(_MAGNUM_${_COMPONENT}_PATH_SUFFIX fontconverters)
             endif()
@@ -530,15 +583,21 @@ foreach(_component ${Magnum_FIND_COMPONENTS})
             set(CMAKE_FIND_LIBRARY_PREFIXES "${CMAKE_FIND_LIBRARY_PREFIXES};")
 
             # Try to find both debug and release version. Dynamic and static
-            # debug libraries are in different places.
-            find_library(MAGNUM_${_COMPONENT}_LIBRARY_DEBUG ${_component}
-                    PATH_SUFFIXES magnum-d/${_MAGNUM_${_COMPONENT}_PATH_SUFFIX})
+            # debug libraries are in different places. Static debug plugins are
+            # in magnum/ with a -d suffix while dynamic debug plugins are in
+            # magnum-d/ with no suffix. Problem is that Vcpkg's library linking
+            # automagic needs the static libs to be in the root library
+            # directory along with everything else and so we need to search for
+            # the -d suffixed version *before* the unsuffixed so it doesn't
+            # pick the release library for both debug and release.
             find_library(MAGNUM_${_COMPONENT}_LIBRARY_DEBUG ${_component}-d
-                    PATH_SUFFIXES magnum/${_MAGNUM_${_COMPONENT}_PATH_SUFFIX})
+                PATH_SUFFIXES magnum/${_MAGNUM_${_COMPONENT}_PATH_SUFFIX})
+            find_library(MAGNUM_${_COMPONENT}_LIBRARY_DEBUG ${_component}
+                PATH_SUFFIXES magnum-d/${_MAGNUM_${_COMPONENT}_PATH_SUFFIX})
             find_library(MAGNUM_${_COMPONENT}_LIBRARY_RELEASE ${_component}
-                    PATH_SUFFIXES magnum/${_MAGNUM_${_COMPONENT}_PATH_SUFFIX})
+                PATH_SUFFIXES magnum/${_MAGNUM_${_COMPONENT}_PATH_SUFFIX})
             mark_as_advanced(MAGNUM_${_COMPONENT}_LIBRARY_DEBUG
-                    MAGNUM_${_COMPONENT}_LIBRARY_RELEASE)
+                MAGNUM_${_COMPONENT}_LIBRARY_RELEASE)
 
             # Reset back
             set(CMAKE_FIND_LIBRARY_PREFIXES "${_tmp_prefixes}")
@@ -548,16 +607,16 @@ foreach(_component ${Magnum_FIND_COMPONENTS})
         if(_component MATCHES ${_MAGNUM_LIBRARY_COMPONENTS} OR _component MATCHES ${_MAGNUM_PLUGIN_COMPONENTS})
             if(MAGNUM_${_COMPONENT}_LIBRARY_RELEASE)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        IMPORTED_CONFIGURATIONS RELEASE)
+                    IMPORTED_CONFIGURATIONS RELEASE)
                 set_property(TARGET Magnum::${_component} PROPERTY
-                        IMPORTED_LOCATION_RELEASE ${MAGNUM_${_COMPONENT}_LIBRARY_RELEASE})
+                    IMPORTED_LOCATION_RELEASE ${MAGNUM_${_COMPONENT}_LIBRARY_RELEASE})
             endif()
 
             if(MAGNUM_${_COMPONENT}_LIBRARY_DEBUG)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        IMPORTED_CONFIGURATIONS DEBUG)
+                    IMPORTED_CONFIGURATIONS DEBUG)
                 set_property(TARGET Magnum::${_component} PROPERTY
-                        IMPORTED_LOCATION_DEBUG ${MAGNUM_${_COMPONENT}_LIBRARY_DEBUG})
+                    IMPORTED_LOCATION_DEBUG ${MAGNUM_${_COMPONENT}_LIBRARY_DEBUG})
             endif()
         endif()
 
@@ -570,7 +629,7 @@ foreach(_component ${Magnum_FIND_COMPONENTS})
 
             if(MAGNUM_${_COMPONENT}_EXECUTABLE)
                 set_property(TARGET Magnum::${_component} PROPERTY
-                        IMPORTED_LOCATION ${MAGNUM_${_COMPONENT}_EXECUTABLE})
+                    IMPORTED_LOCATION ${MAGNUM_${_COMPONENT}_EXECUTABLE})
             endif()
         endif()
 
@@ -582,158 +641,248 @@ foreach(_component ${Magnum_FIND_COMPONENTS})
             if(_component STREQUAL AndroidApplication)
                 find_package(EGL)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES android EGL::EGL)
+                    INTERFACE_LINK_LIBRARIES android EGL::EGL)
 
-                # GLFW application dependencies
+            # EmscriptenApplication has no additional dependencies
+
+            # GLFW application dependencies
             elseif(_component STREQUAL GlfwApplication)
                 find_package(GLFW)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES GLFW::GLFW)
+                    INTERFACE_LINK_LIBRARIES GLFW::GLFW)
+                # Use the Foundation framework on Apple to query the DPI awareness
+                if(CORRADE_TARGET_APPLE)
+                    find_library(_MAGNUM_APPLE_FOUNDATION_FRAMEWORK_LIBRARY Foundation)
+                    mark_as_advanced(_MAGNUM_APPLE_FOUNDATION_FRAMEWORK_LIBRARY)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES ${_MAGNUM_APPLE_FOUNDATION_FRAMEWORK_LIBRARY})
+                # Needed for opt-in DPI queries
+                elseif(CORRADE_TARGET_UNIX)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
+                endif()
 
-                # GLUT application dependencies
-            elseif(_component STREQUAL GlutApplication)
-                find_package(GLUT)
-                set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_INCLUDE_DIRECTORIES ${GLUT_INCLUDE_DIR})
-                set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES ${GLUT_glut_LIBRARY})
+                # With GLVND (since CMake 3.11) we need to explicitly link to
+                # GLX/EGL because libOpenGL doesn't provide it. For EGL we have
+                # our own EGL find module, which makes things simpler. The
+                # upstream FindOpenGL is anything but simple. Also can't use
+                # OpenGL_OpenGL_FOUND, because that one is set also if GLVND is
+                # *not* found. WTF. Also can't just check for
+                # OPENGL_opengl_LIBRARY because that's set even if
+                # OpenGL_GL_PREFERENCE is explicitly set to LEGACY.
+                if(MAGNUM_TARGET_GL)
+                    if(CORRADE_TARGET_UNIX AND NOT CORRADE_TARGET_APPLE AND (NOT MAGNUM_TARGET_GLES OR MAGNUM_TARGET_DESKTOP_GLES))
+                        find_package(OpenGL)
+                        if(OPENGL_opengl_LIBRARY AND OpenGL_GL_PREFERENCE STREQUAL GLVND)
+                            set_property(TARGET Magnum::${_component} APPEND
+                            PROPERTY INTERFACE_LINK_LIBRARIES OpenGL::GLX)
+                        endif()
+                    elseif(MAGNUM_TARGET_GLES AND NOT MAGNUM_TARGET_DESKTOP_GLES AND NOT CORRADE_TARGET_EMSCRIPTEN)
+                        find_package(EGL)
+                        set_property(TARGET Magnum::${_component} APPEND
+                            PROPERTY INTERFACE_LINK_LIBRARIES EGL::EGL)
+                    endif()
+                endif()
 
-                # SDL2 application dependencies
+            # SDL2 application dependencies
             elseif(_component STREQUAL Sdl2Application)
                 find_package(SDL2)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES SDL2::SDL2)
+                    INTERFACE_LINK_LIBRARIES SDL2::SDL2)
+                # Use the Foundation framework on Apple to query the DPI awareness
+                if(CORRADE_TARGET_APPLE)
+                    find_library(_MAGNUM_APPLE_FOUNDATION_FRAMEWORK_LIBRARY Foundation)
+                    mark_as_advanced(_MAGNUM_APPLE_FOUNDATION_FRAMEWORK_LIBRARY)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES ${_MAGNUM_APPLE_FOUNDATION_FRAMEWORK_LIBRARY})
+                # Needed for opt-in DPI queries
+                elseif(CORRADE_TARGET_UNIX)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
+                endif()
 
-                # (Windowless) GLX application dependencies
+                # With GLVND (since CMake 3.11) we need to explicitly link to
+                # GLX/EGL because libOpenGL doesn't provide it. For EGL we have
+                # our own EGL find module, which makes things simpler. The
+                # upstream FindOpenGL is anything but simple. Also can't use
+                # OpenGL_OpenGL_FOUND, because that one is set also if GLVND is
+                # *not* found. WTF. Also can't just check for
+                # OPENGL_opengl_LIBRARY because that's set even if
+                # OpenGL_GL_PREFERENCE is explicitly set to LEGACY.
+                if(MAGNUM_TARGET_GL)
+                    if(CORRADE_TARGET_UNIX AND NOT CORRADE_TARGET_APPLE AND (NOT MAGNUM_TARGET_GLES OR MAGNUM_TARGET_DESKTOP_GLES))
+                        find_package(OpenGL)
+                        if(OPENGL_opengl_LIBRARY AND OpenGL_GL_PREFERENCE STREQUAL GLVND)
+                            set_property(TARGET Magnum::${_component} APPEND
+                            PROPERTY INTERFACE_LINK_LIBRARIES OpenGL::GLX)
+                        endif()
+                    elseif(MAGNUM_TARGET_GLES AND NOT MAGNUM_TARGET_DESKTOP_GLES AND NOT CORRADE_TARGET_EMSCRIPTEN)
+                        find_package(EGL)
+                        set_property(TARGET Magnum::${_component} APPEND
+                            PROPERTY INTERFACE_LINK_LIBRARIES EGL::EGL)
+                    endif()
+                endif()
+
+            # (Windowless) GLX application dependencies
             elseif(_component STREQUAL GlxApplication OR _component STREQUAL WindowlessGlxApplication)
                 find_package(X11)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_INCLUDE_DIRECTORIES ${X11_INCLUDE_DIR})
+                    INTERFACE_INCLUDE_DIRECTORIES ${X11_INCLUDE_DIR})
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES ${X11_LIBRARIES})
+                    INTERFACE_LINK_LIBRARIES ${X11_LIBRARIES})
 
-                # Windowless CGL application has no additional dependencies
+                # With GLVND (since CMake 3.11) we need to explicitly link to
+                # GLX because libOpenGL doesn't provide it. Also can't use
+                # OpenGL_OpenGL_FOUND, because that one is set also if GLVND is
+                # *not* found. WTF. Also can't just check for
+                # OPENGL_opengl_LIBRARY because that's set even if
+                # OpenGL_GL_PREFERENCE is explicitly set to LEGACY.
+                find_package(OpenGL)
+                if(OPENGL_opengl_LIBRARY AND OpenGL_GL_PREFERENCE STREQUAL GLVND)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES OpenGL::GLX)
+                endif()
 
-                # Windowless EGL application dependencies
+            # Windowless CGL application has no additional dependencies
+
+            # Windowless EGL application dependencies
             elseif(_component STREQUAL WindowlessEglApplication)
                 find_package(EGL)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES EGL::EGL)
+                    INTERFACE_LINK_LIBRARIES EGL::EGL)
 
-                # Windowless iOS application dependencies
+            # Windowless iOS application dependencies
             elseif(_component STREQUAL WindowlessIosApplication)
                 # We need to link to Foundation framework to use ObjC
                 find_library(_MAGNUM_IOS_FOUNDATION_FRAMEWORK_LIBRARY Foundation)
                 mark_as_advanced(_MAGNUM_IOS_FOUNDATION_FRAMEWORK_LIBRARY)
                 find_package(EGL)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES EGL::EGL ${_MAGNUM_IOS_FOUNDATION_FRAMEWORK_LIBRARY})
+                    INTERFACE_LINK_LIBRARIES EGL::EGL ${_MAGNUM_IOS_FOUNDATION_FRAMEWORK_LIBRARY})
 
-                # Windowless WGL application has no additional dependencies
+            # Windowless WGL application has no additional dependencies
 
-                # Windowless Windows/EGL application dependencies
+            # Windowless Windows/EGL application dependencies
             elseif(_component STREQUAL WindowlessWindowsEglApplication)
                 find_package(EGL)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES EGL::EGL)
+                    INTERFACE_LINK_LIBRARIES EGL::EGL)
 
-                # X/EGL application dependencies
+            # X/EGL application dependencies
             elseif(_component STREQUAL XEglApplication)
                 find_package(EGL)
                 find_package(X11)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_INCLUDE_DIRECTORIES ${X11_INCLUDE_DIR})
+                    INTERFACE_INCLUDE_DIRECTORIES ${X11_INCLUDE_DIR})
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES EGL::EGL ${X11_LIBRARIES})
+                    INTERFACE_LINK_LIBRARIES EGL::EGL ${X11_LIBRARIES})
             endif()
 
-            # Context libraries
+        # Context libraries
         elseif(_component MATCHES ".+Context")
             set(_MAGNUM_${_COMPONENT}_INCLUDE_PATH_SUFFIX Magnum/Platform)
             set(_MAGNUM_${_COMPONENT}_INCLUDE_PATH_NAMES GLContext.h)
 
             # GLX context dependencies
             if(_component STREQUAL GlxContext)
-                find_package(X11)
-                set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                # With GLVND (since CMake 3.11) we need to explicitly link to
+                # GLX because libOpenGL doesn't provide it. Also can't use
+                # OpenGL_OpenGL_FOUND, because that one is set also if GLVND is
+                # *not* found. If GLVND is not used, link to X11 instead. Also
+                # can't just check for OPENGL_opengl_LIBRARY because that's set
+                # even if OpenGL_GL_PREFERENCE is explicitly set to LEGACY.
+                find_package(OpenGL)
+                if(OPENGL_opengl_LIBRARY AND OpenGL_GL_PREFERENCE STREQUAL GLVND)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES OpenGL::GLX)
+                else()
+                    find_package(X11)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
                         INTERFACE_INCLUDE_DIRECTORIES ${X11_INCLUDE_DIR})
-                set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
                         INTERFACE_LINK_LIBRARIES ${X11_LIBRARIES})
+                endif()
 
-                # EGL context dependencies
+            # EGL context dependencies
             elseif(_component STREQUAL EglContext)
                 find_package(EGL)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES EGL::EGL)
+                    INTERFACE_LINK_LIBRARIES EGL::EGL)
             endif()
 
             # No additional dependencies for CGL context
             # No additional dependencies for WGL context
 
-            # Audio library
+        # Audio library
         elseif(_component STREQUAL Audio)
             find_package(OpenAL)
             set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                    INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR})
-            set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                    INTERFACE_LINK_LIBRARIES ${OPENAL_LIBRARY} Corrade::PluginManager)
+                INTERFACE_LINK_LIBRARIES Corrade::PluginManager OpenAL::OpenAL)
 
-            # No special setup for DebugTools library
+        # No special setup for DebugTools library
 
-            # GL library
+        # GL library
         elseif(_component STREQUAL GL)
-            set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                    INTERFACE_INCLUDE_DIRECTORIES ${MAGNUM_INCLUDE_DIR}/MagnumExternal/OpenGL)
-
             if(NOT MAGNUM_TARGET_GLES OR MAGNUM_TARGET_DESKTOP_GLES)
+                # If the GLVND library (CMake 3.11+) was found, link to the
+                # imported target. Otherwise (and also on all systems except
+                # Linux) link to the classic libGL. Can't use
+                # OpenGL_OpenGL_FOUND, because that one is set also if GLVND is
+                # *not* found. WTF. Also can't just check for
+                # OPENGL_opengl_LIBRARY because that's set even if
+                # OpenGL_GL_PREFERENCE is explicitly set to LEGACY.
                 find_package(OpenGL REQUIRED)
-                set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                if(OPENGL_opengl_LIBRARY AND OpenGL_GL_PREFERENCE STREQUAL GLVND)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES OpenGL::OpenGL)
+                else()
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
                         INTERFACE_LINK_LIBRARIES ${OPENGL_gl_LIBRARY})
+                endif()
             elseif(MAGNUM_TARGET_GLES2)
                 find_package(OpenGLES2 REQUIRED)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES OpenGLES2::OpenGLES2)
+                    INTERFACE_LINK_LIBRARIES OpenGLES2::OpenGLES2)
             elseif(MAGNUM_TARGET_GLES3)
                 find_package(OpenGLES3 REQUIRED)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_LINK_LIBRARIES OpenGLES3::OpenGLES3)
+                    INTERFACE_LINK_LIBRARIES OpenGLES3::OpenGLES3)
             endif()
 
-            # Emscripten needs a special flag to use WebGL 2
-            if(CORRADE_TARGET_EMSCRIPTEN AND NOT MAGNUM_TARGET_GLES2)
-                # TODO: give me INTERFACE_LINK_OPTIONS or something, please
-                set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s USE_WEBGL2=1")
-            endif()
-
-            # MeshTools library
+        # MeshTools library
         elseif(_component STREQUAL MeshTools)
             set(_MAGNUM_${_COMPONENT}_INCLUDE_PATH_NAMES CompressIndices.h)
 
-            # OpenGLTester library
+        # OpenGLTester library
         elseif(_component STREQUAL OpenGLTester)
             set(_MAGNUM_${_COMPONENT}_INCLUDE_PATH_SUFFIX Magnum/GL)
 
-            # Primitives library
+        # Primitives library
         elseif(_component STREQUAL Primitives)
             set(_MAGNUM_${_COMPONENT}_INCLUDE_PATH_NAMES Cube.h)
 
-            # No special setup for SceneGraph library
-            # No special setup for Shaders library
-            # No special setup for Shapes library
+        # No special setup for SceneGraph library
+        # No special setup for Shaders library
 
-            # Text library
+        # Text library
         elseif(_component STREQUAL Text)
             set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                    INTERFACE_LINK_LIBRARIES Corrade::PluginManager)
+                INTERFACE_LINK_LIBRARIES Corrade::PluginManager)
 
-            # TextureTools library
+        # TextureTools library
         elseif(_component STREQUAL TextureTools)
             set(_MAGNUM_${_COMPONENT}_INCLUDE_PATH_NAMES Atlas.h)
 
-            # Trade library
+        # Trade library
         elseif(_component STREQUAL Trade)
             set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                    INTERFACE_LINK_LIBRARIES Corrade::PluginManager)
+                INTERFACE_LINK_LIBRARIES Corrade::PluginManager)
+
+        # Vk library
+        elseif(_component STREQUAL Vk)
+            find_package(Vulkan REQUIRED)
+            set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES Vulkan::Vulkan)
         endif()
 
         # No special setup for AnyAudioImporter plugin
@@ -750,30 +899,42 @@ foreach(_component ${Magnum_FIND_COMPONENTS})
         # Find library/plugin includes
         if(_component MATCHES ${_MAGNUM_LIBRARY_COMPONENTS} OR _component MATCHES ${_MAGNUM_PLUGIN_COMPONENTS})
             find_path(_MAGNUM_${_COMPONENT}_INCLUDE_DIR
-                    NAMES ${_MAGNUM_${_COMPONENT}_INCLUDE_PATH_NAMES}
-                    HINTS ${MAGNUM_INCLUDE_DIR}/${_MAGNUM_${_COMPONENT}_INCLUDE_PATH_SUFFIX})
+                NAMES ${_MAGNUM_${_COMPONENT}_INCLUDE_PATH_NAMES}
+                HINTS ${MAGNUM_INCLUDE_DIR}/${_MAGNUM_${_COMPONENT}_INCLUDE_PATH_SUFFIX})
             mark_as_advanced(_MAGNUM_${_COMPONENT}_INCLUDE_DIR)
         endif()
 
-        # Automatic import of static plugins on CMake >= 3.1
-        if(_component MATCHES ${_MAGNUM_PLUGIN_COMPONENTS} AND NOT CMAKE_VERSION VERSION_LESS 3.1)
+        # Automatic import of static plugins. Skip in case the include dir was
+        # not found -- that'll fail later with a proper message.
+        if(_component MATCHES ${_MAGNUM_PLUGIN_COMPONENTS} AND _MAGNUM_${_COMPONENT}_INCLUDE_DIR)
             # Automatic import of static plugins
             file(READ ${_MAGNUM_${_COMPONENT}_INCLUDE_DIR}/configure.h _magnum${_component}Configure)
             string(FIND "${_magnum${_component}Configure}" "#define MAGNUM_${_COMPONENT}_BUILD_STATIC" _magnum${_component}_BUILD_STATIC)
             if(NOT _magnum${_component}_BUILD_STATIC EQUAL -1)
                 set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                        INTERFACE_SOURCES ${_MAGNUM_${_COMPONENT}_INCLUDE_DIR}/importStaticPlugin.cpp)
+                    INTERFACE_SOURCES ${_MAGNUM_${_COMPONENT}_INCLUDE_DIR}/importStaticPlugin.cpp)
             endif()
         endif()
 
-        # Link to core Magnum library, add inter-library dependencies
+        # Link to core Magnum library, add inter-library dependencies. If there
+        # are optional dependencies, defer adding them to later once we know if
+        # they were found or not.
         if(_component MATCHES ${_MAGNUM_LIBRARY_COMPONENTS} OR _component MATCHES ${_MAGNUM_PLUGIN_COMPONENTS})
             set_property(TARGET Magnum::${_component} APPEND PROPERTY
-                    INTERFACE_LINK_LIBRARIES Magnum::Magnum)
+                INTERFACE_LINK_LIBRARIES Magnum::Magnum)
+            set(_MAGNUM_${component}_OPTIONAL_DEPENDENCIES_TO_ADD )
             foreach(_dependency ${_MAGNUM_${_component}_DEPENDENCIES})
-                set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                if(NOT _MAGNUM_${_component}_${_dependency}_DEPENDENCY_IS_OPTIONAL)
+                    set_property(TARGET Magnum::${_component} APPEND PROPERTY
                         INTERFACE_LINK_LIBRARIES Magnum::${_dependency})
+                else()
+                    list(APPEND _MAGNUM_${_component}_OPTIONAL_DEPENDENCIES_TO_ADD
+                        ${_dependency})
+                endif()
             endforeach()
+            if(_MAGNUM_${_component}_OPTIONAL_DEPENDENCIES_TO_ADD)
+                list(APPEND _MAGNUM_OPTIONAL_DEPENDENCIES_TO_ADD ${_component})
+            endif()
         endif()
 
         # Decide if the library was found
@@ -805,18 +966,56 @@ foreach(_component ${Magnum_FIND_COMPONENTS})
             unset(_MAGNUM_GLCONTEXT_ALIAS)
         endif()
     endif()
-
-    # Deprecated variables
-    if(MAGNUM_BUILD_DEPRECATED AND _component MATCHES ${_MAGNUM_LIBRARY_COMPONENTS} OR _component MATCHES ${_MAGNUM_PLUGIN_COMPONENTS})
-        set(MAGNUM_${_COMPONENT}_LIBRARIES Magnum::${_component})
-    endif()
 endforeach()
+
+# Emscripten-specific files and flags
+if(CORRADE_TARGET_EMSCRIPTEN)
+    find_file(MAGNUM_EMSCRIPTENAPPLICATION_JS EmscriptenApplication.js
+        PATH_SUFFIXES share/magnum)
+    find_file(MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS WindowlessEmscriptenApplication.js
+        PATH_SUFFIXES share/magnum)
+    find_file(MAGNUM_WEBAPPLICATION_CSS WebApplication.css
+        PATH_SUFFIXES share/magnum)
+    mark_as_advanced(
+        MAGNUM_EMSCRIPTENAPPLICATION_JS
+        MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS
+        MAGNUM_WEBAPPLICATION_CSS)
+    set(MAGNUM_EXTRAS_NEEDED
+        MAGNUM_EMSCRIPTENAPPLICATION_JS
+        MAGNUM_WINDOWLESSEMSCRIPTENAPPLICATION_JS
+        MAGNUM_WEBAPPLICATION_CSS)
+
+    # If we are on CMake 3.13 and up, `-s USE_WEBGL2=1` linker option is
+    # propagated from FindOpenGLES3.cmake already. If not (and the GL library
+    # is used), we need to modify the global CMAKE_EXE_LINKER_FLAGS. Do it here
+    # instead of in FindOpenGLES3.cmake so it works also for CMake subprojects
+    # (in which case find_package(OpenGLES3) is called in (and so
+    # CMAKE_EXE_LINKER_FLAGS would be modified in) Magnum's root CMakeLists.txt
+    # and thus can't affect the variable in the outer project). CMake supports
+    # IN_LIST as an operator since 3.1 (Emscripten needs at least 3.7), but
+    # it's behind a policy, so enable that one as well.
+    cmake_policy(SET CMP0057 NEW)
+    if(CMAKE_VERSION VERSION_LESS 3.13 AND GL IN_LIST Magnum_FIND_COMPONENTS AND NOT MAGNUM_TARGET_GLES2 AND NOT CMAKE_EXE_LINKER_FLAGS MATCHES "-s USE_WEBGL2=1")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s USE_WEBGL2=1")
+    endif()
+endif()
 
 # Complete the check with also all components
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Magnum
-        REQUIRED_VARS MAGNUM_INCLUDE_DIR MAGNUM_LIBRARY
-        HANDLE_COMPONENTS)
+    REQUIRED_VARS MAGNUM_INCLUDE_DIR MAGNUM_LIBRARY ${MAGNUM_EXTRAS_NEEDED}
+    HANDLE_COMPONENTS)
+
+# Components with optional dependencies -- add them once we know if they were
+# found or not.
+foreach(_component ${_MAGNUM_OPTIONAL_DEPENDENCIES_TO_ADD})
+    foreach(_dependency ${_MAGNUM_${_component}_OPTIONAL_DEPENDENCIES_TO_ADD})
+        if(Magnum_${_dependency}_FOUND)
+            set_property(TARGET Magnum::${_component} APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES Magnum::${_dependency})
+        endif()
+    endforeach()
+endforeach()
 
 # Create Windowless*Application, *Application and *Context aliases
 # TODO: ugh why can't I make an alias of IMPORTED target?
@@ -826,26 +1025,23 @@ if(_MAGNUM_WINDOWLESSAPPLICATION_ALIAS AND NOT TARGET Magnum::WindowlessApplicat
         add_library(Magnum::WindowlessApplication ALIAS ${_MAGNUM_WINDOWLESSAPPLICATION_ALIASED_TARGET})
     else()
         add_library(Magnum::WindowlessApplication UNKNOWN IMPORTED)
-        get_target_property(_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_CONFIGURATIONS ${_MAGNUM_WINDOWLESSAPPLICATION_ALIAS} IMPORTED_CONFIGURATIONS)
+        foreach(property IMPORTED_CONFIGURATIONS INTERFACE_INCLUDE_DIRECTORIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS INTERFACE_LINK_LIBRARIES)
+            get_target_property(_MAGNUM_WINDOWLESSAPPLICATION_${property} ${_MAGNUM_WINDOWLESSAPPLICATION_ALIAS} ${property})
+            if(_MAGNUM_WINDOWLESSAPPLICATION_${property})
+                set_target_properties(Magnum::WindowlessApplication PROPERTIES
+                    ${property} "${_MAGNUM_WINDOWLESSAPPLICATION_${property}}")
+            endif()
+        endforeach()
         get_target_property(_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_LOCATION_RELEASE ${_MAGNUM_WINDOWLESSAPPLICATION_ALIAS} IMPORTED_LOCATION_RELEASE)
         get_target_property(_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_LOCATION_DEBUG ${_MAGNUM_WINDOWLESSAPPLICATION_ALIAS} IMPORTED_LOCATION_DEBUG)
-        set_target_properties(Magnum::WindowlessApplication PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${_MAGNUM_WINDOWLESSAPPLICATION_ALIAS},INTERFACE_INCLUDE_DIRECTORIES>
-                INTERFACE_COMPILE_DEFINITIONS $<TARGET_PROPERTY:${_MAGNUM_WINDOWLESSAPPLICATION_ALIAS},INTERFACE_COMPILE_DEFINITIONS>
-                INTERFACE_COMPILE_OPTIONS $<TARGET_PROPERTY:${_MAGNUM_WINDOWLESSAPPLICATION_ALIAS},INTERFACE_COMPILE_OPTIONS>
-                INTERFACE_LINK_LIBRARIES $<TARGET_PROPERTY:${_MAGNUM_WINDOWLESSAPPLICATION_ALIAS},INTERFACE_LINK_LIBRARIES>
-                IMPORTED_CONFIGURATIONS "${_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_CONFIGURATIONS}")
         if(_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_LOCATION_RELEASE)
             set_target_properties(Magnum::WindowlessApplication PROPERTIES
-                    IMPORTED_LOCATION_RELEASE ${_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_LOCATION_RELEASE})
+                IMPORTED_LOCATION_RELEASE ${_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_LOCATION_RELEASE})
         endif()
         if(_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_LOCATION_DEBUG)
             set_target_properties(Magnum::WindowlessApplication PROPERTIES
-                    IMPORTED_LOCATION_DEBUG ${_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_LOCATION_DEBUG})
+                IMPORTED_LOCATION_DEBUG ${_MAGNUM_WINDOWLESSAPPLICATION_IMPORTED_LOCATION_DEBUG})
         endif()
-    endif()
-    if(MAGNUM_BUILD_DEPRECATED)
-        set(MAGNUM_WINDOWLESSAPPLICATION_LIBRARIES Magnum::WindowlessApplication)
     endif()
     # Prevent creating the alias again
     unset(_MAGNUM_WINDOWLESSAPPLICATION_ALIAS)
@@ -856,26 +1052,24 @@ if(_MAGNUM_APPLICATION_ALIAS AND NOT TARGET Magnum::Application)
         add_library(Magnum::Application ALIAS ${_MAGNUM_APPLICATION_ALIASED_TARGET})
     else()
         add_library(Magnum::Application UNKNOWN IMPORTED)
-        get_target_property(_MAGNUM_APPLICATION_IMPORTED_CONFIGURATIONS ${_MAGNUM_APPLICATION_ALIAS} IMPORTED_CONFIGURATIONS)
+        foreach(property IMPORTED_CONFIGURATIONS INTERFACE_INCLUDE_DIRECTORIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS INTERFACE_LINK_LIBRARIES)
+            get_target_property(_MAGNUM_APPLICATION_${property}
+                ${_MAGNUM_APPLICATION_ALIAS} ${property})
+            if(_MAGNUM_APPLICATION_${property})
+                set_target_properties(Magnum::Application PROPERTIES ${property}
+                    "${_MAGNUM_APPLICATION_${property}}")
+            endif()
+        endforeach()
         get_target_property(_MAGNUM_APPLICATION_IMPORTED_LOCATION_RELEASE ${_MAGNUM_APPLICATION_ALIAS} IMPORTED_LOCATION_RELEASE)
         get_target_property(_MAGNUM_APPLICATION_IMPORTED_LOCATION_DEBUG ${_MAGNUM_APPLICATION_ALIAS} IMPORTED_LOCATION_DEBUG)
-        set_target_properties(Magnum::Application PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${_MAGNUM_APPLICATION_ALIAS},INTERFACE_INCLUDE_DIRECTORIES>
-                INTERFACE_COMPILE_DEFINITIONS $<TARGET_PROPERTY:${_MAGNUM_APPLICATION_ALIAS},INTERFACE_COMPILE_DEFINITIONS>
-                INTERFACE_COMPILE_OPTIONS $<TARGET_PROPERTY:${_MAGNUM_APPLICATION_ALIAS},INTERFACE_COMPILE_OPTIONS>
-                INTERFACE_LINK_LIBRARIES $<TARGET_PROPERTY:${_MAGNUM_APPLICATION_ALIAS},INTERFACE_LINK_LIBRARIES>
-                IMPORTED_CONFIGURATIONS "${_MAGNUM_APPLICATION_IMPORTED_CONFIGURATIONS}")
         if(_MAGNUM_APPLICATION_IMPORTED_LOCATION_RELEASE)
             set_target_properties(Magnum::Application PROPERTIES
-                    IMPORTED_LOCATION_RELEASE ${_MAGNUM_APPLICATION_IMPORTED_LOCATION_RELEASE})
+                IMPORTED_LOCATION_RELEASE ${_MAGNUM_APPLICATION_IMPORTED_LOCATION_RELEASE})
         endif()
         if(_MAGNUM_APPLICATION_IMPORTED_LOCATION_DEBUG)
             set_target_properties(Magnum::Application PROPERTIES
-                    IMPORTED_LOCATION_DEBUG ${_MAGNUM_APPLICATION_IMPORTED_LOCATION_DEBUG})
+                IMPORTED_LOCATION_DEBUG ${_MAGNUM_APPLICATION_IMPORTED_LOCATION_DEBUG})
         endif()
-    endif()
-    if(MAGNUM_BUILD_DEPRECATED)
-        set(MAGNUM_APPLICATION_LIBRARIES Magnum::Application)
     endif()
     # Prevent creating the alias again
     unset(_MAGNUM_APPLICATION_ALIAS)
@@ -886,22 +1080,22 @@ if(_MAGNUM_GLCONTEXT_ALIAS AND NOT TARGET Magnum::GLContext)
         add_library(Magnum::GLContext ALIAS ${_MAGNUM_GLCONTEXT_ALIASED_TARGET})
     else()
         add_library(Magnum::GLContext UNKNOWN IMPORTED)
-        get_target_property(_MAGNUM_GLCONTEXT_IMPORTED_CONFIGURATIONS ${_MAGNUM_GLCONTEXT_ALIAS} IMPORTED_CONFIGURATIONS)
+        foreach(property IMPORTED_CONFIGURATIONS INTERFACE_INCLUDE_DIRECTORIES INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_OPTIONS INTERFACE_LINK_LIBRARIES)
+            get_target_property(_MAGNUM_GLCONTEXT_${property} ${_MAGNUM_GLCONTEXT_ALIAS} ${property})
+            if(_MAGNUM_GLCONTEXT_${property})
+                set_target_properties(Magnum::GLContext PROPERTIES ${property}
+                    "${_MAGNUM_GLCONTEXT_${property}}")
+            endif()
+        endforeach()
         get_target_property(_MAGNUM_GLCONTEXT_IMPORTED_LOCATION_RELEASE ${_MAGNUM_GLCONTEXT_ALIAS} IMPORTED_LOCATION_RELEASE)
         get_target_property(_MAGNUM_GLCONTEXT_IMPORTED_LOCATION_DEBUG ${_MAGNUM_GLCONTEXT_ALIAS} IMPORTED_LOCATION_DEBUG)
-        set_target_properties(Magnum::GLContext PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${_MAGNUM_GLCONTEXT_ALIAS},INTERFACE_INCLUDE_DIRECTORIES>
-                INTERFACE_COMPILE_DEFINITIONS $<TARGET_PROPERTY:${_MAGNUM_GLCONTEXT_ALIAS},INTERFACE_COMPILE_DEFINITIONS>
-                INTERFACE_COMPILE_OPTIONS $<TARGET_PROPERTY:${_MAGNUM_GLCONTEXT_ALIAS},INTERFACE_COMPILE_OPTIONS>
-                INTERFACE_LINK_LIBRARIES $<TARGET_PROPERTY:${_MAGNUM_GLCONTEXT_ALIAS},INTERFACE_LINK_LIBRARIES>
-                IMPORTED_CONFIGURATIONS "${_MAGNUM_GLCONTEXT_IMPORTED_CONFIGURATIONS}")
         if(_MAGNUM_GLCONTEXT_IMPORTED_LOCATION_RELEASE)
             set_target_properties(Magnum::GLContext PROPERTIES
-                    IMPORTED_LOCATION_RELEASE ${_MAGNUM_GLCONTEXT_IMPORTED_LOCATION_RELEASE})
+                IMPORTED_LOCATION_RELEASE ${_MAGNUM_GLCONTEXT_IMPORTED_LOCATION_RELEASE})
         endif()
         if(_MAGNUM_GLCONTEXT_IMPORTED_LOCATION_DEBUG)
             set_target_properties(Magnum::GLContext PROPERTIES
-                    IMPORTED_LOCATION_DEBUG ${_MAGNUM_GLCONTEXT_IMPORTED_LOCATION_DEBUG})
+                IMPORTED_LOCATION_DEBUG ${_MAGNUM_GLCONTEXT_IMPORTED_LOCATION_DEBUG})
         endif()
     endif()
     # Prevent creating the alias again
@@ -910,9 +1104,9 @@ endif()
 
 # Installation and deploy dirs
 set(MAGNUM_DEPLOY_PREFIX "."
-        CACHE STRING "Prefix where to put final application executables")
+    CACHE STRING "Prefix where to put final application executables")
 set(MAGNUM_INCLUDE_INSTALL_PREFIX "."
-        CACHE STRING "Prefix where to put platform-independent include and other files")
+    CACHE STRING "Prefix where to put platform-independent include and other files")
 
 include(${CORRADE_LIB_SUFFIX_MODULE})
 set(MAGNUM_BINARY_INSTALL_DIR bin)
@@ -936,42 +1130,52 @@ set(MAGNUM_PLUGINS_IMPORTER_DEBUG_BINARY_INSTALL_DIR ${MAGNUM_PLUGINS_DEBUG_BINA
 set(MAGNUM_PLUGINS_IMPORTER_DEBUG_LIBRARY_INSTALL_DIR ${MAGNUM_PLUGINS_DEBUG_LIBRARY_INSTALL_DIR}/importers)
 set(MAGNUM_PLUGINS_IMPORTER_RELEASE_BINARY_INSTALL_DIR ${MAGNUM_PLUGINS_RELEASE_BINARY_INSTALL_DIR}/importers)
 set(MAGNUM_PLUGINS_IMPORTER_RELEASE_LIBRARY_INSTALL_DIR ${MAGNUM_PLUGINS_RELEASE_LIBRARY_INSTALL_DIR}/importers)
+set(MAGNUM_PLUGINS_SCENECONVERTER_DEBUG_BINARY_INSTALL_DIR ${MAGNUM_PLUGINS_DEBUG_BINARY_INSTALL_DIR}/sceneconverters)
+set(MAGNUM_PLUGINS_SCENECONVERTER_DEBUG_LIBRARY_INSTALL_DIR ${MAGNUM_PLUGINS_DEBUG_LIBRARY_INSTALL_DIR}/sceneconverters)
+set(MAGNUM_PLUGINS_SCENECONVERTER_RELEASE_LIBRARY_INSTALL_DIR ${MAGNUM_PLUGINS_RELEASE_LIBRARY_INSTALL_DIR}/sceneconverters)
+set(MAGNUM_PLUGINS_SCENECONVERTER_RELEASE_BINARY_INSTALL_DIR ${MAGNUM_PLUGINS_RELEASE_BINARY_INSTALL_DIR}/sceneconverters)
 set(MAGNUM_PLUGINS_AUDIOIMPORTER_DEBUG_BINARY_INSTALL_DIR ${MAGNUM_PLUGINS_DEBUG_BINARY_INSTALL_DIR}/audioimporters)
 set(MAGNUM_PLUGINS_AUDIOIMPORTER_DEBUG_LIBRARY_INSTALL_DIR ${MAGNUM_PLUGINS_DEBUG_LIBRARY_INSTALL_DIR}/audioimporters)
 set(MAGNUM_PLUGINS_AUDIOIMPORTER_RELEASE_BINARY_INSTALL_DIR ${MAGNUM_PLUGINS_RELEASE_BINARY_INSTALL_DIR}/audioimporters)
 set(MAGNUM_PLUGINS_AUDIOIMPORTER_RELEASE_LIBRARY_INSTALL_DIR ${MAGNUM_PLUGINS_RELEASE_LIBRARY_INSTALL_DIR}/audioimporters)
 set(MAGNUM_INCLUDE_INSTALL_DIR ${MAGNUM_INCLUDE_INSTALL_PREFIX}/include/Magnum)
+set(MAGNUM_EXTERNAL_INCLUDE_INSTALL_DIR ${MAGNUM_INCLUDE_INSTALL_PREFIX}/include/MagnumExternal)
 set(MAGNUM_PLUGINS_INCLUDE_INSTALL_DIR ${MAGNUM_INCLUDE_INSTALL_PREFIX}/include/MagnumPlugins)
 
 # Get base plugin directory from main library location. This is *not* PATH,
 # because CMake always converts the path to an absolute location internally,
 # making it impossible to specify relative paths there. Sorry in advance for
 # not having the dir selection button in CMake GUI.
-set(MAGNUM_PLUGINS_DEBUG_DIR ${_MAGNUM_PLUGINS_DIR_PREFIX}/magnum-d
-        CACHE STRING "Base directory where to look for Magnum plugins for debug builds")
-set(MAGNUM_PLUGINS_RELEASE_DIR ${_MAGNUM_PLUGINS_DIR_PREFIX}/magnum
-        CACHE STRING "Base directory where to look for Magnum plugins for release builds")
-set(MAGNUM_PLUGINS_DIR ${_MAGNUM_PLUGINS_DIR_PREFIX}/magnum${_MAGNUM_PLUGINS_DIR_SUFFIX}
-        CACHE STRING "Base directory where to look for Magnum plugins")
+set(MAGNUM_PLUGINS_DEBUG_DIR ""
+    CACHE STRING "Base directory where to look for Magnum plugins for debug builds")
+set(MAGNUM_PLUGINS_RELEASE_DIR ""
+    CACHE STRING "Base directory where to look for Magnum plugins for release builds")
+set(MAGNUM_PLUGINS_DIR ""
+    CACHE STRING "Base directory where to look for Magnum plugins")
 
-# Plugin directories
-set(MAGNUM_PLUGINS_FONT_DIR ${MAGNUM_PLUGINS_DIR}/fonts)
-set(MAGNUM_PLUGINS_FONT_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/fonts)
-set(MAGNUM_PLUGINS_FONT_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/fonts)
-set(MAGNUM_PLUGINS_FONTCONVERTER_DIR ${MAGNUM_PLUGINS_DIR}/fontconverters)
-set(MAGNUM_PLUGINS_FONTCONVERTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/fontconverters)
-set(MAGNUM_PLUGINS_FONTCONVERTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/fontconverters)
-set(MAGNUM_PLUGINS_IMAGECONVERTER_DIR ${MAGNUM_PLUGINS_DIR}/imageconverters)
-set(MAGNUM_PLUGINS_IMAGECONVERTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/imageconverters)
-set(MAGNUM_PLUGINS_IMAGECONVERTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/imageconverters)
-set(MAGNUM_PLUGINS_IMPORTER_DIR ${MAGNUM_PLUGINS_DIR}/importers)
-set(MAGNUM_PLUGINS_IMPORTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/importers)
-set(MAGNUM_PLUGINS_IMPORTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/importers)
-set(MAGNUM_PLUGINS_AUDIOIMPORTER_DIR ${MAGNUM_PLUGINS_DIR}/audioimporters)
-set(MAGNUM_PLUGINS_AUDIOIMPORTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/audioimporters)
-set(MAGNUM_PLUGINS_AUDIOIMPORTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/audioimporters)
-
-# Deprecated variables
-if(MAGNUM_BUILD_DEPRECATED)
-    set(MAGNUM_LIBRARIES Magnum::Magnum)
+# Plugin directories. Set only if the above are non-empty. otherwise empty as
+# well.
+if(MAGNUM_PLUGINS_DIR)
+    set(MAGNUM_PLUGINS_FONT_DIR ${MAGNUM_PLUGINS_DIR}/fonts)
+    set(MAGNUM_PLUGINS_FONTCONVERTER_DIR ${MAGNUM_PLUGINS_DIR}/fontconverters)
+    set(MAGNUM_PLUGINS_IMAGECONVERTER_DIR ${MAGNUM_PLUGINS_DIR}/imageconverters)
+    set(MAGNUM_PLUGINS_IMPORTER_DIR ${MAGNUM_PLUGINS_DIR}/importers)
+    set(MAGNUM_PLUGINS_SCENECONVERTER_DIR ${MAGNUM_PLUGINS_DIR}/sceneconverters)
+    set(MAGNUM_PLUGINS_AUDIOIMPORTER_DIR ${MAGNUM_PLUGINS_DIR}/audioimporters)
+endif()
+if(MAGNUM_PLUGINS_DEBUG_DIR)
+    set(MAGNUM_PLUGINS_FONT_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/fonts)
+    set(MAGNUM_PLUGINS_FONTCONVERTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/fontconverters)
+    set(MAGNUM_PLUGINS_IMAGECONVERTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/imageconverters)
+    set(MAGNUM_PLUGINS_IMPORTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/importers)
+    set(MAGNUM_PLUGINS_FONT_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/fonts)
+    set(MAGNUM_PLUGINS_SCENECONVERTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/sceneconverters)
+    set(MAGNUM_PLUGINS_AUDIOIMPORTER_DEBUG_DIR ${MAGNUM_PLUGINS_DEBUG_DIR}/audioimporters)
+endif()
+if(MAGNUM_PLUGINS_RELEASE_DIR)
+    set(MAGNUM_PLUGINS_FONTCONVERTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/fontconverters)
+    set(MAGNUM_PLUGINS_IMAGECONVERTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/imageconverters)
+    set(MAGNUM_PLUGINS_IMPORTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/importers)
+    set(MAGNUM_PLUGINS_SCENECONVERTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/sceneconverters)
+    set(MAGNUM_PLUGINS_AUDIOIMPORTER_RELEASE_DIR ${MAGNUM_PLUGINS_RELEASE_DIR}/audioimporters)
 endif()

--- a/modules/FindNodeJs.cmake
+++ b/modules/FindNodeJs.cmake
@@ -1,0 +1,45 @@
+#.rst:
+# Find Node.js
+# ------------
+#
+# Finds the Node.js executable. This module defines:
+#
+#  NodeJs_FOUND         - True if Node.js executable is found
+#  NodeJs::NodeJs       - Node.js executable imported target
+#
+
+#
+#   This file is part of Corrade.
+#
+#   Copyright © 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016,
+#               2017, 2018, 2019, 2020 Vladimír Vondruš <mosra@centrum.cz>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+find_program(NODEJS_EXECUTABLE node)
+mark_as_advanced(NODEJS_EXECUTABLE)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args("NodeJs" DEFAULT_MSG NODEJS_EXECUTABLE)
+
+if(NOT TARGET NodeJs::NodeJs)
+    add_executable(NodeJs::NodeJs IMPORTED)
+    set_property(TARGET NodeJs::NodeJs PROPERTY IMPORTED_LOCATION ${NODEJS_EXECUTABLE})
+endif()

--- a/modules/FindOpenAL.cmake
+++ b/modules/FindOpenAL.cmake
@@ -1,0 +1,169 @@
+#.rst:
+# Find OpenAL
+# -----------
+#
+# Finds the OpenAL library. This module defines:
+#
+#  OpenAL_FOUND         - True if the OpenAL library is found
+#  OpenAL::OpenAL       - OpenAL imported target
+#
+# Additionally these variables are defined for internal usage:
+#
+#  OPENAL_LIBRARY       - OpenAL library
+#  OPENAL_DLL_RELEASE   - OpenAL release DLL on Windows, if found. Note that
+#   in case of the binary OpenAL Soft distribution it's named soft_oal.dll and
+#   you need to rename it to OpenAL32.dll to make it work.
+#  OPENAL_INCLUDE_DIR   - Include dir
+#
+
+#
+#   This file is part of Magnum.
+#
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020 Vladimír Vondruš <mosra@centrum.cz>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+# OpenAL Soft installs cmake package config files which handles dependencies in
+# case OpenAL Soft is built statically. Try to find first, quietly, so it
+# doesn't print loud messages when it's not found, since that's okay. If the
+# OpenAL target already exists, it means we're using it through a CMake
+# subproject -- don't attempt to find the package in that case.
+#
+# In case of Emscripten we don't want any of this -- the library name and
+# includes are implicit.
+if(NOT CORRADE_TARGET_EMSCRIPTEN AND NOT TARGET OpenAL)
+    find_package(OpenAL CONFIG QUIET)
+endif()
+
+# If either an OpenAL Soft config file was found or we have a subproject, point
+# OpenAL::OpenAL to that and exit -- nothing else to do here.
+if(TARGET OpenAL OR TARGET OpenAL::OpenAL)
+    # OpenAL Soft config file already defines this one, so this is just for
+    # the subproject case.
+    if(NOT TARGET OpenAL::OpenAL)
+        # Aliases of (global) targets are only supported in CMake 3.11, so we
+        # work around it by this. This is easier than fetching all possible
+        # properties (which are impossible to track of) and then attempting to
+        # rebuild them into a new target.
+        add_library(OpenAL::OpenAL INTERFACE IMPORTED)
+        set_target_properties(OpenAL::OpenAL PROPERTIES INTERFACE_LINK_LIBRARIES OpenAL)
+
+        # The OpenAL target doesn't define any usable
+        # INTERFACE_INCLUDE_DIRECTORIES for some reason (apparently the
+        # $<BUILD_INTERFACE:> in there doesn't work or whatever), so let's do
+        # that ourselves.
+        get_target_property(_OPENAL_SOURCE_DIR OpenAL SOURCE_DIR)
+        set_target_properties(OpenAL::OpenAL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${_OPENAL_SOURCE_DIR}/include/AL)
+
+    # For the imported target get the DLL location
+    else()
+        if(CORRADE_TARGET_WINDOWS)
+            get_target_property(OPENAL_DLL_DEBUG OpenAL::OpenAL   IMPORTED_LOCATION_DEBUG)
+            get_target_property(OPENAL_DLL_RELEASE OpenAL::OpenAL IMPORTED_LOCATION_RELEASE)
+            # Release not found, fall back to RelWithDebInfo
+            if(NOT OPENAL_DLL_RELEASE)
+                get_target_property(OPENAL_DLL_RELEASE OpenAL::OpenAL IMPORTED_LOCATION_RELWITHDEBINFO)
+            endif()
+        endif()
+    endif()
+
+    # Just to make FPHSA print some meaningful location, nothing else.
+    # Fortunately because of the INTERFACE_INCLUDE_DIRECTORIES workaround above
+    # we can have the same handling both in case of an imported target and a
+    # CMake subproject.
+    get_target_property(_OPENAL_INTERFACE_INCLUDE_DIRECTORIES OpenAL::OpenAL INTERFACE_INCLUDE_DIRECTORIES)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args("OpenAL" DEFAULT_MSG
+        _OPENAL_INTERFACE_INCLUDE_DIRECTORIES)
+
+    return()
+endif()
+
+# Under Emscripten, OpenAL is linked implicitly. With MINIMAL_RUNTIME you need
+# to specify -lopenal. Simply set the library name to that.
+if(CORRADE_TARGET_EMSCRIPTEN)
+    set(OPENAL_LIBRARY openal CACHE STRING "Path to a library." FORCE)
+else()
+    # OpenAL Soft Windows binary distribution puts the library into a subdir,
+    # the legacy one from Creative uses the same. OpenAL Soft puts DLLs into
+    # bin/Win{32,64}/soft_oal.dll
+    if(WIN32)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            set(_OPENAL_LIBRARY_PATH_SUFFIX libs/Win64)
+            set(_OPENAL_DLL_PATH_SUFFIX bin/Win64)
+        elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+            set(_OPENAL_LIBRARY_PATH_SUFFIX libs/Win32)
+            set(_OPENAL_DLL_PATH_SUFFIX bin/Win32)
+        endif()
+    endif()
+
+    find_library(OPENAL_LIBRARY
+        # Names same as in CMake's vanilla FindOpenAL
+        NAMES OpenAL al openal OpenAL32
+        # For binary OpenAL Soft distribution on Windows
+        PATH_SUFFIXES ${_OPENAL_LIBRARY_PATH_SUFFIX}
+        # The other PATHS from CMake's vanilla FindOpenAL seem to be a legacy
+        # cruft, skipping those. The Windows registry used by the vanilla
+        # FindOpenAL doesn't seem to be set anymore either.
+        )
+endif()
+
+# Include dir
+find_path(OPENAL_INCLUDE_DIR NAMES al.h
+    # AL/ used by OpenAL Soft, OpenAL/ used by the macOS framework. The legacy
+    # Creative SDK puts al.h directly into include/, ffs.
+    PATH_SUFFIXES AL OpenAL
+    # As above, skipping the obsolete PATHS and registry in vanilla FindOpenAL
+    )
+
+# OpenAL DLL on Windows
+if(CORRADE_TARGET_WINDOWS)
+    # TODO: debug?
+    find_file(OPENAL_DLL_RELEASE
+        NAMES soft_oal.dll
+        PATH_SUFFIXES ${_OPENAL_DLL_PATH_SUFFIX})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenAL DEFAULT_MSG
+    OPENAL_LIBRARY
+    OPENAL_INCLUDE_DIR)
+
+if(NOT TARGET OpenAL::OpenAL)
+    # Work around BUGGY framework support on macOS. Do this also in case of
+    # Emscripten, since there we don't have a location either.
+    # http://public.kitware.com/pipermail/cmake/2016-April/063179.html
+    if((APPLE AND ${OPENAL_LIBRARY} MATCHES "\\.framework$") OR CORRADE_TARGET_EMSCRIPTEN)
+        add_library(OpenAL::OpenAL INTERFACE IMPORTED)
+        set_property(TARGET OpenAL::OpenAL APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES ${OPENAL_LIBRARY})
+    else()
+        add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
+        set_property(TARGET OpenAL::OpenAL PROPERTY
+            IMPORTED_LOCATION ${OPENAL_LIBRARY})
+    endif()
+
+    set_target_properties(OpenAL::OpenAL PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR})
+endif()
+
+mark_as_advanced(OPENAL_LIBRARY OPENAL_INCLUDE_DIR)

--- a/modules/FindOpenGLES2.cmake
+++ b/modules/FindOpenGLES2.cmake
@@ -10,14 +10,17 @@
 # Additionally these variables are defined for internal usage:
 #
 #  OPENGLES2_LIBRARY        - OpenGL ES 2 library
-#  OPENGLES2_INCLUDE_DIR    - Include dir
+#
+# Please note this find module is tailored especially for the needs of Magnum.
+# In particular, it depends on its platform definitions and doesn't look for
+# OpenGL ES includes as Magnum has its own, generated using flextGL.
 #
 
 #
 #   This file is part of Magnum.
 #
-#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018
-#             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020 Vladimír Vondruš <mosra@centrum.cz>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -38,9 +41,11 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-# In Emscripten OpenGL ES 2 is linked automatically, thus no need to find the
-# library.
-if(NOT CORRADE_TARGET_EMSCRIPTEN)
+# Under Emscripten, GL is linked implicitly. With MINIMAL_RUNTIME you need to
+# specify -lGL. Simply set the library name to that.
+if(CORRADE_TARGET_EMSCRIPTEN)
+    set(OPENGLES2_LIBRARY GL CACHE STRING "Path to a library." FORCE)
+else()
     find_library(OPENGLES2_LIBRARY NAMES
         GLESv2
 
@@ -49,41 +54,25 @@ if(NOT CORRADE_TARGET_EMSCRIPTEN)
 
         # iOS
         OpenGLES)
-    set(OPENGLES2_LIBRARY_NEEDED OPENGLES2_LIBRARY)
 endif()
-
-# Include dir
-find_path(OPENGLES2_INCLUDE_DIR NAMES
-    GLES2/gl2.h
-
-    # iOS
-    ES2/gl.h)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(OpenGLES2 DEFAULT_MSG
-    ${OPENGLES2_LIBRARY_NEEDED}
-    OPENGLES2_INCLUDE_DIR)
+    OPENGLES2_LIBRARY)
 
 if(NOT TARGET OpenGLES2::OpenGLES2)
-    if(OPENGLES2_LIBRARY_NEEDED)
-        # Work around BUGGY framework support on macOS
-        # http://public.kitware.com/pipermail/cmake/2016-April/063179.html
-        if(CORRADE_TARGET_APPLE AND ${OPENGLES2_LIBRARY} MATCHES "\\.framework$")
-            add_library(OpenGLES2::OpenGLES2 INTERFACE IMPORTED)
-            set_property(TARGET OpenGLES2::OpenGLES2 APPEND PROPERTY
-                INTERFACE_LINK_LIBRARIES ${OPENGLES2_LIBRARY})
-        else()
-            add_library(OpenGLES2::OpenGLES2 UNKNOWN IMPORTED)
-            set_property(TARGET OpenGLES2::OpenGLES2 PROPERTY
-                IMPORTED_LOCATION ${OPENGLES2_LIBRARY})
-        endif()
-    else()
-        # This won't work in CMake 2.8.12, but that affects Emscripten only so
-        # I assume people building for that are not on that crap old Ubuntu
-        # 14.04 LTS
+    # Work around BUGGY framework support on macOS. Do this also in case of
+    # Emscripten, since there we don't have a location either.
+    # http://public.kitware.com/pipermail/cmake/2016-April/063179.html
+    if((CORRADE_TARGET_APPLE AND ${OPENGLES2_LIBRARY} MATCHES "\\.framework$") OR CORRADE_TARGET_EMSCRIPTEN)
         add_library(OpenGLES2::OpenGLES2 INTERFACE IMPORTED)
+        set_property(TARGET OpenGLES2::OpenGLES2 APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES ${OPENGLES2_LIBRARY})
+    else()
+        add_library(OpenGLES2::OpenGLES2 UNKNOWN IMPORTED)
+        set_property(TARGET OpenGLES2::OpenGLES2 PROPERTY
+            IMPORTED_LOCATION ${OPENGLES2_LIBRARY})
     endif()
-
-    set_property(TARGET OpenGLES2::OpenGLES2 PROPERTY
-        INTERFACE_INCLUDE_DIRECTORIES ${OPENGLES2_INCLUDE_DIR})
 endif()
+
+mark_as_advanced(OPENGLES2_LIBRARY)

--- a/modules/FindOpenGLES3.cmake
+++ b/modules/FindOpenGLES3.cmake
@@ -10,14 +10,17 @@
 # Additionally these variables are defined for internal usage:
 #
 #  OPENGLES3_LIBRARY        - OpenGL ES 3 library
-#  OPENGLES3_INCLUDE_DIR    - Include dir
+#
+# Please note this find module is tailored especially for the needs of Magnum.
+# In particular, it depends on its platform definitions and doesn't look for
+# OpenGL ES includes as Magnum has its own, generated using flextGL.
 #
 
 #
 #   This file is part of Magnum.
 #
-#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018
-#             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020 Vladimír Vondruš <mosra@centrum.cz>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -38,9 +41,11 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-# In Emscripten OpenGL ES 3 is linked automatically, thus no need to find the
-# library.
-if(NOT CORRADE_TARGET_EMSCRIPTEN)
+# Under Emscripten, GL is linked implicitly. With MINIMAL_RUNTIME you need to
+# specify -lGL. Simply set the library name to that.
+if(CORRADE_TARGET_EMSCRIPTEN)
+    set(OPENGLES3_LIBRARY GL CACHE STRING "Path to a library." FORCE)
+else()
     find_library(OPENGLES3_LIBRARY NAMES
         GLESv3
 
@@ -53,41 +58,35 @@ if(NOT CORRADE_TARGET_EMSCRIPTEN)
 
         # iOS
         OpenGLES)
-    set(OPENGLES3_LIBRARY_NEEDED OPENGLES3_LIBRARY)
 endif()
-
-# Include dir
-find_path(OPENGLES3_INCLUDE_DIR NAMES
-    GLES3/gl3.h
-
-    # iOS
-    ES3/gl.h)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args("OpenGLES3" DEFAULT_MSG
-    ${OPENGLES3_LIBRARY_NEEDED}
-    OPENGLES3_INCLUDE_DIR)
+    OPENGLES3_LIBRARY)
 
 if(NOT TARGET OpenGLES3::OpenGLES3)
-    if(OPENGLES3_LIBRARY_NEEDED)
-        # Work around BUGGY framework support on macOS
-        # http://public.kitware.com/pipermail/cmake/2016-April/063179.html
-        if(CORRADE_TARGET_APPLE AND ${OPENGLES3_LIBRARY} MATCHES "\\.framework$")
-            add_library(OpenGLES3::OpenGLES3 INTERFACE IMPORTED)
-            set_property(TARGET OpenGLES3::OpenGLES3 APPEND PROPERTY
-                INTERFACE_LINK_LIBRARIES ${OPENGLES3_LIBRARY})
-        else()
-            add_library(OpenGLES3::OpenGLES3 UNKNOWN IMPORTED)
-            set_property(TARGET OpenGLES3::OpenGLES3 PROPERTY
-                IMPORTED_LOCATION ${OPENGLES3_LIBRARY})
-        endif()
-    else()
-        # This won't work in CMake 2.8.12, but that affects Emscripten only so
-        # I assume people building for that are not on that crap old Ubuntu
-        # 14.04 LTS
+    # Work around BUGGY framework support on macOS. Do this also in case of
+    # Emscripten, since there we don't have a location either.
+    # http://public.kitware.com/pipermail/cmake/2016-April/063179.html
+    if((CORRADE_TARGET_APPLE AND ${OPENGLES3_LIBRARY} MATCHES "\\.framework$") OR CORRADE_TARGET_EMSCRIPTEN)
         add_library(OpenGLES3::OpenGLES3 INTERFACE IMPORTED)
+        set_property(TARGET OpenGLES3::OpenGLES3 APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES ${OPENGLES3_LIBRARY})
+    else()
+        add_library(OpenGLES3::OpenGLES3 UNKNOWN IMPORTED)
+        set_property(TARGET OpenGLES3::OpenGLES3 PROPERTY
+            IMPORTED_LOCATION ${OPENGLES3_LIBRARY})
     endif()
 
-    set_property(TARGET OpenGLES3::OpenGLES3 PROPERTY
-        INTERFACE_INCLUDE_DIRECTORIES ${OPENGLES3_INCLUDE_DIR})
+    # Emscripten needs a special flag to use WebGL 2. CMake 3.13 allows to set
+    # this via INTERFACE_LINK_OPTIONS, for older versions we modify the global
+    # CMAKE_EXE_LINKER_FLAGS inside FindMagnum.cmake.
+    if(CORRADE_TARGET_EMSCRIPTEN AND NOT CMAKE_VERSION VERSION_LESS 3.13)
+        # I could probably use target_link_options() here, but let's be
+        # consistent with the rest
+        set_property(TARGET OpenGLES3::OpenGLES3 APPEND PROPERTY
+            INTERFACE_LINK_OPTIONS "SHELL:-s USE_WEBGL2=1")
+    endif()
 endif()
+
+mark_as_advanced(OPENGLES3_LIBRARY)

--- a/modules/FindSDL2.cmake
+++ b/modules/FindSDL2.cmake
@@ -9,15 +9,19 @@
 #
 # Additionally these variables are defined for internal usage:
 #
-#  SDL2_LIBRARY             - SDL2 library
+#  SDL2_LIBRARY_DEBUG       - SDL2 debug library, if found
+#  SDL2_LIBRARY_RELEASE     - SDL2 release library, if found
+#  SDL2_DLL_DEBUG           - SDL2 debug DLL on Windows, if found
+#  SDL2_DLL_RELEASE         - SDL2 release DLL on Windows, if found
 #  SDL2_INCLUDE_DIR         - Root include dir
 #
 
 #
 #   This file is part of Magnum.
 #
-#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018
-#             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020 Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2018 Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -43,22 +47,53 @@
 if(CORRADE_TARGET_EMSCRIPTEN)
     set(_SDL2_PATH_SUFFIXES SDL)
 else()
-    # Precompiled libraries for Windows are in x86/x64 subdirectories
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        set(_SDL_LIBRARY_PATH_SUFFIX lib/x64)
-    elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
-        set(_SDL_LIBRARY_PATH_SUFFIX lib/x86)
+    set(_SDL2_PATH_SUFFIXES SDL2)
+    if(WIN32)
+        # Precompiled libraries for MSVC are in x86/x64 subdirectories
+        if(MSVC)
+            if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+                set(_SDL2_LIBRARY_PATH_SUFFIX lib/x64)
+            elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set(_SDL2_LIBRARY_PATH_SUFFIX lib/x86)
+            endif()
+
+        # Both includes and libraries for MinGW are in some directory deep
+        # inside. There's also a CMake config file but it has HARDCODED path
+        # to /opt/local/i686-w64-mingw32, which doesn't make ANY SENSE,
+        # especially on Windows.
+        elseif(MINGW)
+            if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+                set(_SDL2_LIBRARY_PATH_SUFFIX x86_64-w64-mingw32/lib)
+                set(_SDL2_RUNTIME_PATH_SUFFIX x86_64-w64-mingw32/bin)
+                list(APPEND _SDL2_PATH_SUFFIXES x86_64-w64-mingw32/include/SDL2)
+            elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set(_SDL2_LIBRARY_PATH_SUFFIX i686-w64-mingw32/lib)
+                set(_SDL2_RUNTIME_PATH_SUFFIX i686-w64-mingw32/lib)
+                list(APPEND _SDL2_PATH_SUFFIXES i686-w64-mingw32/include/SDL2)
+            endif()
+        else()
+            message(FATAL_ERROR "Unsupported compiler")
+        endif()
     endif()
 
-    find_library(SDL2_LIBRARY
+    find_library(SDL2_LIBRARY_RELEASE
         # Compiling SDL2 from scratch on macOS creates dead libSDL2.so symlink
         # which CMake somehow prefers before the SDL2-2.0.dylib file. Making
-        # the dylib first so it is preferred.
+        # the dylib first so it is preferred. Not sure how this maps to debug
+        # config though :/
         NAMES SDL2-2.0 SDL2
-        PATH_SUFFIXES ${_SDL_LIBRARY_PATH_SUFFIX})
+        PATH_SUFFIXES ${_SDL2_LIBRARY_PATH_SUFFIX})
+    find_library(SDL2_LIBRARY_DEBUG
+        NAMES SDL2d
+        PATH_SUFFIXES ${_SDL2_LIBRARY_PATH_SUFFIX})
+    # FPHSA needs one of the _DEBUG/_RELEASE variables to check that the
+    # library was found -- using SDL_LIBRARY, which will get populated by
+    # select_library_configurations() below.
     set(SDL2_LIBRARY_NEEDED SDL2_LIBRARY)
-    set(_SDL2_PATH_SUFFIXES SDL2)
 endif()
+
+include(SelectLibraryConfigurations)
+select_library_configurations(SDL2)
 
 # Include dir
 find_path(SDL2_INCLUDE_DIR
@@ -72,17 +107,43 @@ find_path(SDL2_INCLUDE_DIR
     NAMES SDL_scancode.h
     PATH_SUFFIXES ${_SDL2_PATH_SUFFIXES})
 
-# iOS dependencies
-if(CORRADE_TARGET_IOS)
-    set(_SDL2_FRAMEWORKS
-        AudioToolbox
-        AVFoundation
-        CoreGraphics
-        CoreMotion
-        Foundation
-        GameController
-        QuartzCore
-        UIKit)
+# DLL on Windows
+if(CORRADE_TARGET_WINDOWS)
+    find_file(SDL2_DLL_RELEASE
+        NAMES SDL2.dll
+        PATH_SUFFIXES ${_SDL2_RUNTIME_PATH_SUFFIX} ${_SDL2_LIBRARY_PATH_SUFFIX})
+    find_file(SDL2_DLL_DEBUG
+        NAMES SDL2d.dll # not sure?
+        PATH_SUFFIXES ${_SDL2_RUNTIME_PATH_SUFFIX} ${_SDL2_LIBRARY_PATH_SUFFIX})
+endif()
+
+# (Static) macOS / iOS dependencies
+if(CORRADE_TARGET_APPLE AND SDL2_LIBRARY MATCHES ".*libSDL2.a$")
+    if(CORRADE_TARGET_IOS)
+        set(_SDL2_FRAMEWORKS
+            AudioToolbox
+            AVFoundation
+            CoreGraphics
+            CoreMotion
+            Foundation
+            GameController
+            Metal # needed since 2.0.8
+            QuartzCore
+            UIKit)
+    else()
+        # Those are needed when building SDL statically using its CMake project
+        set(_SDL2_FRAMEWORKS
+            iconv # should be in the system
+            AudioToolbox
+            AVFoundation
+            Carbon
+            Cocoa
+            CoreAudio
+            CoreVideo
+            ForceFeedback
+            Foundation
+            IOKit)
+    endif()
     set(_SDL2_FRAMEWORK_LIBRARIES )
     foreach(framework ${_SDL2_FRAMEWORKS})
         find_library(_SDL2_${framework}_LIBRARY ${framework})
@@ -100,51 +161,68 @@ find_package_handle_standard_args("SDL2" DEFAULT_MSG
 
 if(NOT TARGET SDL2::SDL2)
     if(SDL2_LIBRARY_NEEDED)
-        # CMake 3.0 doesn't propagate the local target as dependency upwards
-        # the tree and then complains that SDL2::SDL2 target was not found,
-        # which it shouldn't. This is reproducible with the base bootstrap
-        # project *and* when using Magnum as CMake subproject. Works with both
-        # 2.8.12 and 3.1, so I'm assuming this is a CMake 3.0 bug. The
-        # workaround is to make the target GLOBAL so it's propagated upwards
-        # the tree unconditionally. For some reason, UNKNOWN targets can't be
-        # marked as GLOBAL, so I'm  biting the bullet and saying the library is
-        # shared -- CMake 3.0 is only on Debian Jessie now and I'm assuming SDL
-        # comes from system libsdl2-dev package, which *is* shared. Hopefully
-        # this won't bite back in the future.
-        if(CMAKE_VERSION VERSION_GREATER "2.8.12.2" AND CMAKE_VERSION VERSION_LESS "3.1.0")
-            set(_SDL2_IMPORTED_LIBRARY_KIND SHARED IMPORTED GLOBAL)
-        else()
-            set(_SDL2_IMPORTED_LIBRARY_KIND UNKNOWN IMPORTED)
-        endif()
-        add_library(SDL2::SDL2 ${_SDL2_IMPORTED_LIBRARY_KIND})
+        add_library(SDL2::SDL2 UNKNOWN IMPORTED)
 
         # Work around BUGGY framework support on macOS
         # https://cmake.org/Bug/view.php?id=14105
-        if(CORRADE_TARGET_APPLE AND ${SDL2_LIBRARY} MATCHES "\\.framework$")
-            set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION ${SDL2_LIBRARY}/SDL2)
+        if(CORRADE_TARGET_APPLE AND SDL2_LIBRARY_RELEASE MATCHES "\\.framework$")
+            set_property(TARGET SDL2::SDL2 APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+            set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION_RELEASE ${SDL2_LIBRARY_RELEASE}/SDL2)
         else()
-            set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION ${SDL2_LIBRARY})
+            if(SDL2_LIBRARY_RELEASE)
+                set_property(TARGET SDL2::SDL2 APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+                set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION_RELEASE ${SDL2_LIBRARY_RELEASE})
+            endif()
+
+            if(SDL2_LIBRARY_DEBUG)
+                set_property(TARGET SDL2::SDL2 APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+                set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION_DEBUG ${SDL2_LIBRARY_DEBUG})
+            endif()
         endif()
 
-        # Link frameworks on iOS
-        if(CORRADE_TARGET_IOS)
+        # Link additional `dl` and `pthread` libraries required by a static
+        # build of SDL on Unixy platforms (except Apple, where it is most
+        # probably some frameworks instead)
+        if(CORRADE_TARGET_UNIX AND NOT CORRADE_TARGET_APPLE AND (SDL2_LIBRARY_DEBUG MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$" OR SDL2_LIBRARY_RELEASE MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$"))
+            find_package(Threads REQUIRED)
+            set_property(TARGET SDL2::SDL2 APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES Threads::Threads ${CMAKE_DL_LIBS})
+        endif()
+
+        # Link frameworks on macOS / iOS if we have a static SDL
+        if(CORRADE_TARGET_APPLE AND SDL2_LIBRARY MATCHES ".*libSDL2.a$")
             set_property(TARGET SDL2::SDL2 APPEND PROPERTY
                 INTERFACE_LINK_LIBRARIES ${_SDL2_FRAMEWORK_LIBRARIES})
         endif()
 
-        # Link also EGL library, if on ES (and not on WebGL)
-        if(MAGNUM_TARGET_GLES AND NOT MAGNUM_TARGET_DESKTOP_GLES AND NOT MAGNUM_TARGET_WEBGL)
-            find_package(EGL REQUIRED)
-            set_property(TARGET SDL2::SDL2 APPEND PROPERTY
-                INTERFACE_LINK_LIBRARIES EGL::EGL)
+        # Windows dependencies for a static library. Unfortunately there's no
+        # easy way to figure out if a *.lib is static or dynamic, so we're
+        # adding only if a DLL is not found.
+        if(CORRADE_TARGET_WINDOWS AND NOT CORRADE_TARGET_WINDOWS_RT AND NOT SDL2_DLL_RELEASE AND NOT SDL2_DLL_DEBUG)
+            set_property(TARGET SDL2::SDL2 APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+                # https://github.com/SDL-mirror/SDL/blob/release-2.0.10/CMakeLists.txt#L1338
+                user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 setupapi shell32
+                # https://github.com/SDL-mirror/SDL/blob/release-2.0.10/CMakeLists.txt#L1384
+                dinput8)
+            # https://github.com/SDL-mirror/SDL/blob/release-2.0.10/CMakeLists.txt#L1422
+            # additionally has dxerr for MSVC if DirectX SDK is not used, but
+            # according to https://walbourn.github.io/wheres-dxerr-lib/ this
+            # thing is long deprecated.
+            if(MINGW)
+                set_property(TARGET SDL2::SDL2 APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+                    # https://github.com/SDL-mirror/SDL/blob/release-2.0.10/CMakeLists.txt#L1386
+                    dxerr8
+                    # https://github.com/SDL-mirror/SDL/blob/release-2.0.10/CMakeLists.txt#L1388
+                    mingw32)
+            endif()
         endif()
+
     else()
-        # This won't work in CMake 2.8.12, but that affects Emscripten only so
-        # I assume people building for that are not on that crap old Ubuntu
-        # 14.04 LTS
         add_library(SDL2::SDL2 INTERFACE IMPORTED)
     endif()
 
     set_property(TARGET SDL2::SDL2 PROPERTY
         INTERFACE_INCLUDE_DIRECTORIES ${SDL2_INCLUDE_DIR})
 endif()
+
+mark_as_advanced(SDL2_INCLUDE_DIR)

--- a/modules/FindVulkan.cmake
+++ b/modules/FindVulkan.cmake
@@ -1,0 +1,87 @@
+#.rst:
+# Find Vulkan
+# -----------
+#
+# Finds the Vulkan library. This module defines:
+#
+#  Vulkan_FOUND         - True if Vulkan library is found
+#  Vulkan::Vulkan       - Vulkan imported target
+#
+# Additionally these variables are defined for internal usage:
+#
+#  Vulkan_LIBRARY       - Vulkan library
+#
+# Please note this find module is tailored especially for the needs of Magnum.
+# In particular, it doesn't look for Vulkan includes as Magnum has its own,
+# generated using flextGL.
+#
+
+#
+#   This file is part of Magnum.
+#
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020 Vladimír Vondruš <mosra@centrum.cz>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+# LunarG SDK on Windows. Same as in CMake's vanilla FindVulkan.cmake in 3.18.
+if(WIN32)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        find_library(Vulkan_LIBRARY
+            NAMES vulkan-1
+            HINTS
+                "$ENV{VULKAN_SDK}/Lib"
+                "$ENV{VULKAN_SDK}/Bin"
+        )
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        find_library(Vulkan_LIBRARY
+            NAMES vulkan-1
+            HINTS
+                "$ENV{VULKAN_SDK}/Lib32"
+                "$ENV{VULKAN_SDK}/Bin32")
+    endif()
+endif()
+
+# Other distributions / systems
+find_library(Vulkan_LIBRARY
+    NAMES
+        # Linux
+        vulkan
+
+        # MSYS packages have libvulkan.dll
+        libvulkan
+
+        # MoltenVK (installed by Homebrew). Specified after (lib)vulkan because
+        # the official loader is preferred, however MoltenVK alone works as
+        # well: https://www.lunarg.com/benefits-of-the-vulkan-macos-sdk/
+        MoltenVK
+    PATHS
+        "$ENV{VULKAN_SDK}/lib")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Vulkan DEFAULT_MSG Vulkan_LIBRARY)
+
+if(NOT TARGET Vulkan::Vulkan)
+    add_library(Vulkan::Vulkan UNKNOWN IMPORTED)
+    set_property(TARGET Vulkan::Vulkan PROPERTY
+        IMPORTED_LOCATION ${Vulkan_LIBRARY})
+endif()
+
+mark_as_advanced(Vulkan_LIBRARY)

--- a/modules/MagnumConfig.cmake
+++ b/modules/MagnumConfig.cmake
@@ -1,0 +1,26 @@
+#
+#   This file is part of Magnum.
+#
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020 Vladimír Vondruš <mosra@centrum.cz>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindMagnum.cmake)

--- a/src/MyApplication.cpp
+++ b/src/MyApplication.cpp
@@ -3,6 +3,7 @@
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/Renderer.h>
+#include <Magnum/Math/Color.h>
 #include <Magnum/MeshTools/Compile.h>
 #include <Magnum/Platform/Sdl2Application.h>
 #include <Magnum/Primitives/Cube.h>
@@ -29,8 +30,8 @@ typedef SceneGraph::Object<SceneGraph::MatrixTransformation3D> Object3D;
 class ExampleCube: public Object3D, public SceneGraph::Drawable3D {
 public:
     explicit ExampleCube(Object3D* parent, SceneGraph::DrawableGroup3D* group): Object3D{parent}, SceneGraph::Drawable3D{*this, group} {
-        std::tie(_mesh, _vertices, _indices) = MeshTools::compile(Primitives::cubeSolid(), GL::BufferUsage::StaticDraw);
-        _color = Color3::fromHsv(216.0_degf, 0.85f, 1.0f);
+        _mesh = MeshTools::compile(Primitives::cubeSolid());
+        _color = Color3::fromHsv(ColorHsv(216.0_degf, 0.85f, 1.0f));
     }
 
 private:
@@ -43,16 +44,15 @@ private:
                 .setNormalMatrix(transformationMatrix.rotation())
                 .setProjectionMatrix(camera.projectionMatrix());
 
-        _mesh.draw(_shader);
+        _shader.draw(_mesh);
     }
 public:
     void changeColor() {
-        _color = Color3::fromHsv(_color.hue() + 50.0_degf, 1.0f, 1.0f);
+        _color = Color3::fromHsv(ColorHsv(_color.hue() + 50.0_degf,1.0f, 1.0f));
         _shader.setDiffuseColor(_color);
     }
 
     GL::Mesh _mesh;
-    std::unique_ptr<GL::Buffer> _vertices, _indices;
     Shaders::Phong _shader;
 };
 
@@ -63,7 +63,7 @@ class MyApplication: public Platform::Application {
 
     private:
         void drawEvent() override;
-        void viewportEvent(const Vector2i& size) override;
+        void viewportEvent(ViewportEvent& event) override;
         void keyPressEvent(KeyEvent& event) override;
         void mousePressEvent(MouseEvent& event) override;
         void mouseReleaseEvent(MouseEvent& event) override;
@@ -106,7 +106,7 @@ MyApplication::MyApplication(const Arguments& arguments) : Platform::Application
 
     _cube->setTransformation(_transformation);
 
-    _color = Color3::fromHsv(35.0_degf, 1.0f, 1.0f);
+    _color =  Color3::fromHsv(ColorHsv(35.0_degf, 1.0f, 1.0f));
 }
 
 void MyApplication::drawEvent() {
@@ -114,9 +114,9 @@ void MyApplication::drawEvent() {
     _camera->draw(_drawables);
 }
 
-void MyApplication::viewportEvent(const Vector2i& size) {
-    GL::defaultFramebuffer.setViewport({{}, size});
-    _camera->setViewport(size);
+void MyApplication::viewportEvent(ViewportEvent& event) {
+    GL::defaultFramebuffer.setViewport({{}, event.framebufferSize()});
+    _camera->setViewport(event.framebufferSize());
 }
 
 void MyApplication::keyPressEvent(KeyEvent& event) {


### PR DESCRIPTION
Hey hey. I am currently looking for a quick bootstrappy thing for porting magnum to web. I saw this, updated the libraries for magnum 2020. 

The changes in myApplication:
- fromHSV function signature changed. update for it.
- mesh compiling changed.
- viewport resize function signature changed.

Rest of changes:
- New module find files for cmake. 